### PR TITLE
feat: Display currency name in payment request messages

### DIFF
--- a/examples/python/adk-demo/client_agent/client_agent.py
+++ b/examples/python/adk-demo/client_agent/client_agent.py
@@ -196,10 +196,14 @@ You are a master orchestrator agent. Your job is to complete user requests by de
             if not requirements:
                 raise ValueError("Server requested payment but sent no requirements.")
 
+            if not requirements.accepts:
+                raise ValueError("Server requested payment but sent no valid payment options.")
+
             # Extract details for the confirmation message.
-            product_name = requirements.accepts[0].extra.get("product", {}).get("name", "the item")
-            currency_amount = requirements.accepts[0].max_amount_required
-            currency_name = requirements.accepts[0].extra.get("name", "TOKEN")
+            payment_option = requirements.accepts[0]
+            currency_amount = payment_option.max_amount_required
+            currency_name = payment_option.extra.get("name", "TOKEN")
+            product_name = payment_option.extra.get("product", {}).get("name", "the item")
 
             return f"The merchant is requesting payment for '{product_name}' for {currency_amount} {currency_name}. Do you want to approve this payment?"
 

--- a/examples/python/adk-demo/client_agent/client_agent.py
+++ b/examples/python/adk-demo/client_agent/client_agent.py
@@ -198,9 +198,10 @@ You are a master orchestrator agent. Your job is to complete user requests by de
 
             # Extract details for the confirmation message.
             product_name = requirements.accepts[0].extra.get("product", {}).get("name", "the item")
-            price = requirements.accepts[0].max_amount_required
-            
-            return f"The merchant is requesting payment for '{product_name}' for {price} units. Do you want to approve this payment?"
+            currency_amount = requirements.accepts[0].max_amount_required
+            currency_name = requirements.accepts[0].extra.get("name", "TOKEN")
+
+            return f"The merchant is requesting payment for '{product_name}' for {currency_amount} {currency_name}. Do you want to approve this payment?"
 
         elif response_task.status.state in (TaskState.completed, TaskState.failed):
             # The task is finished. Report the outcome.


### PR DESCRIPTION
## Summary
- Improve payment request UX by displaying the actual currency name (e.g., USDC) instead of generic "units"
- Extract currency name from payment requirements extra field with fallback to "TOKEN"
- Update message format to standard crypto notation

**Before:**
> The merchant is requesting payment for 'Apple' for 11112871 units. Do you want to approve this payment?

**After:**
> The merchant is requesting payment for 'Apple' for 11112871 USDC. Do you want to approve this payment?

## Test plan
- [ ] Test payment request flow with USDC currency
- [ ] Verify fallback behavior when currency name is missing
- [ ] Confirm message readability and format