### PR TITLE
feat: Add Bitcoin Cashu support

### DIFF
--- a/python/x402_a2a/core/wallet.py
+++ b/python/x402_a2a/core/wallet.py
@@ -47,12 +47,19 @@ def process_payment_required(
     client = x402Client(account=account, max_value=max_value)
     selected_requirement = client.select_payment_requirements(payment_required.accepts)
 
+    if selected_requirement.scheme == "cashu-token":
+        raise ValueError(
+            "cashu-token requirements must be processed with explicit Cashu proofs via partners.cashu helpers"
+        )
+
     # Create payment payload
     return process_payment(selected_requirement, account, max_value)
 
 
 def process_payment(
-    requirements: PaymentRequirements, account: Account, max_value: Optional[int] = None
+    requirements: PaymentRequirements,
+    account: Account,
+    max_value: Optional[int] = None,
 ) -> PaymentPayload:
     """Create PaymentPayload using proper x402.exact signing logic.
     Same as create_payment_header but returns PaymentPayload object (not base64 encoded).
@@ -67,6 +74,10 @@ def process_payment(
     """
     # TODO: Future x402 library update will provide direct PaymentPayload creation
     # For now, we use the prepare -> sign -> decode pattern
+    if requirements.scheme == "cashu-token":
+        raise ValueError(
+            "cashu-token requirements must be handled via partners.cashu helpers"
+        )
 
     # Step 1: Prepare unsigned payment header
     unsigned_payload = prepare_payment_header(

--- a/python/x402_a2a/partners/__init__.py
+++ b/python/x402_a2a/partners/__init__.py
@@ -1,0 +1,7 @@
+"""Partner-specific integrations for x402_a2a."""
+
+from . import cashu
+
+__all__ = [
+    "cashu",
+]

--- a/python/x402_a2a/partners/cashu/README.md
+++ b/python/x402_a2a/partners/cashu/README.md
@@ -1,0 +1,41 @@
+# Cashu Partner Helpers
+
+Use these helpers to integrate Cashu payments without extending the core `x402_a2a.core` modules.
+
+## Creating payment requirements
+
+```python
+from x402_a2a.partners.cashu import create_cashu_payment_requirements
+
+requirements = create_cashu_payment_requirements(
+    price=1000,
+    pay_to_address="cashu:merchant",
+    resource="/cashu",
+    network="bitcoin-testnet",
+    mint_urls=["https://nofees.testnut.cashu.space/"],
+    facilitator_url="https://facilitator.example",
+    keyset_ids=["keyset-1"],
+)
+```
+
+The helper enforces:
+- An explicit or default mint for the chosen Bitcoin network
+- Whole-number satoshi prices
+- Optional partner metadata such as facilitator URLs, keysets, and NUT-10 locks
+
+## Processing a Cashu payment
+
+```python
+from x402_a2a.partners.cashu import process_cashu_payment
+from x402_a2a.core.wallet import process_payment_required
+
+payload = ...  # `CashuPaymentPayload`
+requirements = ...  # `PaymentRequirements`
+
+payment_payload = process_cashu_payment(
+    requirements=requirements,
+    cashu_payload=payload,
+)
+```
+
+Call `process_payment_required` only for non-Cashu schemes. For Cashu, use `process_cashu_payment` directly so you can supply the encoded proofs.

--- a/python/x402_a2a/partners/cashu/__init__.py
+++ b/python/x402_a2a/partners/cashu/__init__.py
@@ -1,0 +1,11 @@
+"""Cashu partner helpers."""
+
+from .helpers import (
+    create_cashu_payment_requirements,
+    process_cashu_payment,
+)
+
+__all__ = [
+    "create_cashu_payment_requirements",
+    "process_cashu_payment",
+]

--- a/python/x402_a2a/partners/cashu/helpers.py
+++ b/python/x402_a2a/partners/cashu/helpers.py
@@ -1,0 +1,157 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for integrating Cashu payments with the x402 A2A SDK."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from x402.common import x402_VERSION
+from x402.types import Price
+
+from ...types import (
+    CashuPaymentPayload,
+    PaymentPayload,
+    PaymentRequirements,
+    SupportedNetworks,
+)
+
+
+_DEFAULT_CASHU_MINTS: dict[str, str] = {
+    "bitcoin-testnet": "https://nofees.testnut.cashu.space/",
+    "bitcoin-mainnet": "https://mint.minibits.cash/Bitcoin",
+}
+
+
+def _resolve_identifiers(
+    collection: list[str] | None, singular: str | None
+) -> list[str]:
+    """Return the first non-empty list between collection and singular."""
+    if collection:
+        return collection
+    if singular:
+        return [singular]
+    return []
+
+
+def create_cashu_payment_requirements(
+    *,
+    price: Price,
+    pay_to_address: str,
+    resource: str,
+    network: str = "base",
+    description: str = "",
+    mime_type: str = "application/json",
+    scheme: str = "cashu-token",
+    max_timeout_seconds: int = 600,
+    output_schema: Any | None = None,
+    mint_url: str | None = None,
+    mint_urls: list[str] | None = None,
+    facilitator_url: str | None = None,
+    keyset_id: str | None = None,
+    keyset_ids: list[str] | None = None,
+    unit: str = "sat",
+    locks: Any | None = None,
+    **kwargs: Any,
+) -> PaymentRequirements:
+    """Build a Cashu-specific `PaymentRequirements` object."""
+    resolved_mints = _resolve_identifiers(mint_urls, mint_url)
+
+    if not resolved_mints:
+        default_mint = _DEFAULT_CASHU_MINTS.get(network)
+        if default_mint:
+            resolved_mints = [default_mint]
+
+    if not resolved_mints:
+        raise ValueError(
+            f"A 'mint_url' must be provided for 'cashu-token' when network '{network}' has no default mint."
+        )
+
+    if isinstance(price, (int, float)):
+        if isinstance(price, float) and price != int(price):
+            raise ValueError("cashu-token price must be a whole number of satoshis")
+        amount_str = str(int(price))
+    elif isinstance(price, str):
+        amount_str = price.strip()
+        if not amount_str.isdigit():
+            raise ValueError("cashu-token price string must be an integer")
+    elif isinstance(price, dict):
+        raise ValueError("cashu-token scheme expects a numeric price, not TokenAmount")
+    else:
+        raise ValueError("Unsupported price type for cashu-token scheme")
+
+    extra: dict[str, Any] = {"mints": resolved_mints, "unit": unit}
+    if facilitator_url:
+        extra["facilitatorUrl"] = facilitator_url
+    resolved_keysets = _resolve_identifiers(keyset_ids, keyset_id)
+    if resolved_keysets:
+        extra["keysetIds"] = resolved_keysets
+    if locks is not None:
+        extra["nut10"] = locks
+
+    extra_kwargs = dict(kwargs)
+    asset = extra_kwargs.pop("asset", None)
+
+    return PaymentRequirements(
+        scheme=scheme,
+        network=cast(SupportedNetworks, network),
+        asset=asset,
+        pay_to=pay_to_address,
+        max_amount_required=amount_str,
+        resource=resource,
+        description=description,
+        mime_type=mime_type,
+        max_timeout_seconds=max_timeout_seconds,
+        output_schema=output_schema,
+        extra=extra,
+        **extra_kwargs,
+    )
+
+
+def process_cashu_payment(
+    *,
+    requirements: PaymentRequirements,
+    cashu_payload: CashuPaymentPayload | None,
+) -> PaymentPayload:
+    """Create a `PaymentPayload` for Cashu flows."""
+    if requirements.scheme != "cashu-token":
+        raise ValueError("process_cashu_payment expects cashu-token requirements")
+
+    if cashu_payload is None:
+        raise ValueError(
+            "cashu_payload must be provided when processing cashu-token payments"
+        )
+
+    extra = requirements.extra if isinstance(requirements.extra, dict) else {}
+    accepted_mints = set(extra.get("mints", []))
+    if accepted_mints:
+        payload_mints = {token.mint for token in cashu_payload.tokens}
+        missing = sorted(payload_mints - accepted_mints)
+        if missing:
+            raise ValueError(
+                "Cashu payload contains mints not accepted by the payment requirements: "
+                + ", ".join(missing)
+            )
+
+    if len(cashu_payload.encoded) != len(cashu_payload.tokens):
+        raise ValueError(
+            "Cashu payload encoded tokens must align with provided token entries"
+        )
+
+    return PaymentPayload(
+        x402_version=x402_VERSION,
+        scheme=requirements.scheme,
+        network=requirements.network,
+        payload=cashu_payload,
+    )

--- a/python/x402_a2a/pyproject.toml
+++ b/python/x402_a2a/pyproject.toml
@@ -38,7 +38,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-force-include = { "__init__.py" = "x402_a2a/__init__.py", "core" = "x402_a2a/core", "executors" = "x402_a2a/executors", "types" = "x402_a2a/types", "extension.py" = "x402_a2a/extension.py" }
+force-include = { "__init__.py" = "x402_a2a/__init__.py", "core" = "x402_a2a/core", "executors" = "x402_a2a/executors", "types" = "x402_a2a/types", "partners" = "x402_a2a/partners", "extension.py" = "x402_a2a/extension.py" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/python/x402_a2a/tests/partners/test_cashu.py
+++ b/python/x402_a2a/tests/partners/test_cashu.py
@@ -1,0 +1,194 @@
+"""Tests for the Cashu partner helpers."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from x402_a2a.partners.cashu import (
+    create_cashu_payment_requirements,
+    process_cashu_payment,
+)
+from x402_a2a.core.wallet import process_payment_required
+from x402_a2a.types import (
+    CashuPaymentPayload,
+    PaymentRequirements,
+    x402PaymentRequiredResponse,
+)
+
+
+def _build_cashu_requirement(**overrides) -> PaymentRequirements:
+    base_kwargs = {
+        "price": 1000,
+        "pay_to_address": "cashu:merchant",
+        "resource": "/cashu",
+        "network": "bitcoin-testnet",
+        "mint_urls": ["https://nofees.testnut.cashu.space/"],
+    }
+    base_kwargs.update(overrides)
+    return create_cashu_payment_requirements(**base_kwargs)
+
+
+def test_create_cashu_payment_requirements():
+    requirements = create_cashu_payment_requirements(
+        price=6000,
+        pay_to_address="cashu:merchant",
+        resource="/cashu",
+        network="bitcoin-testnet",
+        mint_urls=["https://nofees.testnut.cashu.space/"],
+        keyset_id="keyset-1",
+    )
+
+    assert requirements.scheme == "cashu-token"
+    assert requirements.max_amount_required == "6000"
+    assert requirements.extra["mints"] == ["https://nofees.testnut.cashu.space/"]
+    assert requirements.extra["keysetIds"] == ["keyset-1"]
+
+
+def test_create_cashu_payment_requirements_missing_mint():
+    with pytest.raises(ValueError) as exc:
+        create_cashu_payment_requirements(
+            price=1000,
+            pay_to_address="cashu:merchant",
+            resource="/cashu",
+            network="bitcoin-regtest",
+        )
+
+    assert "network 'bitcoin-regtest'" in str(exc.value)
+
+
+def test_create_cashu_payment_requirements_fractional_price():
+    with pytest.raises(ValueError) as exc:
+        create_cashu_payment_requirements(
+            price=0.5,
+            pay_to_address="cashu:merchant",
+            resource="/cashu",
+            network="bitcoin-testnet",
+        )
+
+    assert "whole number" in str(exc.value)
+
+
+def test_create_cashu_payment_requirements_invalid_string_price():
+    with pytest.raises(ValueError):
+        create_cashu_payment_requirements(
+            price="12.3",
+            pay_to_address="cashu:merchant",
+            resource="/cashu",
+            network="bitcoin-testnet",
+        )
+
+
+def test_process_cashu_payment():
+    requirements = _build_cashu_requirement(price="5000")
+
+    payload = CashuPaymentPayload(
+        tokens=[
+            {
+                "mint": "https://nofees.testnut.cashu.space/",
+                "proofs": [
+                    {
+                        "amount": 5000,
+                        "secret": "secret",
+                        "C": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                        "id": "001122aabbccdd",
+                    }
+                ],
+            }
+        ],
+        encoded=["cashuBexample"],
+        payer="payer-id",
+    )
+
+    result = process_cashu_payment(requirements=requirements, cashu_payload=payload)
+
+    assert result.scheme == "cashu-token"
+    assert result.payload.tokens[0].mint == "https://nofees.testnut.cashu.space/"
+
+
+def test_process_cashu_payment_requires_payload():
+    requirements = _build_cashu_requirement()
+
+    with pytest.raises(ValueError):
+        process_cashu_payment(requirements=requirements, cashu_payload=None)
+
+
+def test_process_cashu_payment_mismatched_mints():
+    requirements = _build_cashu_requirement()
+
+    payload = CashuPaymentPayload(
+        tokens=[
+            {
+                "mint": "https://mint.minibits.cash/Bitcoin",
+                "proofs": [
+                    {
+                        "amount": 1000,
+                        "secret": "secret",
+                        "C": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                        "id": "001122aabbccdd",
+                    }
+                ],
+            }
+        ],
+        encoded=["cashuBexample"],
+    )
+
+    with pytest.raises(ValueError) as exc:
+        process_cashu_payment(requirements=requirements, cashu_payload=payload)
+
+    assert "mint.minibits.cash" in str(exc.value)
+
+
+def test_process_cashu_payment_encoded_length_mismatch():
+    requirements = _build_cashu_requirement()
+
+    valid_payload = CashuPaymentPayload(
+        tokens=[
+            {
+                "mint": "https://nofees.testnut.cashu.space/",
+                "proofs": [
+                    {
+                        "amount": 1000,
+                        "secret": "secret",
+                        "C": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                        "id": "001122aabbccdd",
+                    }
+                ],
+            }
+        ],
+        encoded=["cashuBexample"],
+    )
+    payload = CashuPaymentPayload.model_construct(
+        tokens=valid_payload.tokens,
+        encoded=[],
+        memo=valid_payload.memo,
+        unit=valid_payload.unit,
+        locks=valid_payload.locks,
+        payer=valid_payload.payer,
+        expiry=valid_payload.expiry,
+    )
+
+    with pytest.raises(ValueError):
+        process_cashu_payment(requirements=requirements, cashu_payload=payload)
+
+
+def test_process_payment_required_rejects_cashu(monkeypatch):
+    cashu_requirement = _build_cashu_requirement()
+
+    class DummyClient:
+        def __init__(self, *_, **__):
+            pass
+
+        def select_payment_requirements(self, accepts):
+            return accepts[0]
+
+    monkeypatch.setattr("x402_a2a.core.wallet.x402Client", DummyClient)
+
+    payment_required = x402PaymentRequiredResponse(
+        x402_version=1,
+        accepts=[cashu_requirement],
+        error="",
+    )
+
+    with pytest.raises(ValueError) as exc:
+        process_payment_required(payment_required, account=MagicMock())
+
+    assert "partners.cashu" in str(exc.value)

--- a/python/x402_a2a/tests/test_core.py
+++ b/python/x402_a2a/tests/test_core.py
@@ -16,8 +16,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 from a2a.types import Task, Message, TaskState, TaskStatus, TextPart
 from x402_a2a.executors.server import x402ServerExecutor
-from x402_a2a.core.merchant import create_payment_requirements
-from x402_a2a.core.wallet import process_payment
 from x402_a2a.types import (
     PaymentStatus,
     x402Metadata,

--- a/python/x402_a2a/tests/test_core.py
+++ b/python/x402_a2a/tests/test_core.py
@@ -16,6 +16,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 from a2a.types import Task, Message, TaskState, TaskStatus, TextPart
 from x402_a2a.executors.server import x402ServerExecutor
+from x402_a2a.core.merchant import create_payment_requirements
+from x402_a2a.core.wallet import process_payment
 from x402_a2a.types import (
     PaymentStatus,
     x402Metadata,

--- a/python/x402_a2a/types/__init__.py
+++ b/python/x402_a2a/types/__init__.py
@@ -26,6 +26,7 @@ from a2a.server.agent_execution.agent_executor import AgentExecutor
 from a2a.server.agent_execution.context import RequestContext
 from a2a.server.events.event_queue import EventQueue
 from x402.types import (
+    CashuPaymentPayload,
     PaymentRequirements,
     x402PaymentRequiredResponse,
     PaymentPayload,
@@ -74,6 +75,7 @@ __all__ = [
     "PaymentRequirements",
     "x402PaymentRequiredResponse",
     "PaymentPayload",
+    "CashuPaymentPayload",
     "VerifyResponse",
     "SettleResponse",
     "ExactPaymentPayload",


### PR DESCRIPTION
## Summary
- move Cashu-specific requirement creation and payment processing into `x402_a2a.partners.cashu`
- keep `core.merchant` and `core.wallet` generic by rejecting Cashu schemes and delegating to the partner helpers
- add partner-focused tests, docs, and packaging metadata so the new helpers ship with the SDK
- Sister PRs: https://github.com/coinbase/x402/pull/385, https://github.com/google-agentic-commerce/AP2/pull/24
