### PR TITLE
BREAKING CHANGE: Update network field to use caip2 schema

### DIFF
--- a/examples/python/adk-demo/server/agents/adk_merchant_agent.py
+++ b/examples/python/adk-demo/server/agents/adk_merchant_agent.py
@@ -61,7 +61,7 @@ class AdkMerchantAgent(BaseAgent):
         price = self._get_product_price(product_name)
         requirements = PaymentRequirements(
             scheme="exact",
-            network="base-sepolia",
+            network="eip155:84532",  # Base Sepolia testnet
             asset="0x036CbD53842c5426634e7929541eC2318f3dCF7e",
             pay_to=self._wallet_address,
             max_amount_required=price,

--- a/python/x402_a2a/README.md
+++ b/python/x402_a2a/README.md
@@ -142,7 +142,7 @@ class x402ServerConfig(BaseModel):
     """Configuration for how a server expects to be paid"""
     price: Union[str, int, TokenAmount]        # Payment price (Money or TokenAmount)
     pay_to_address: str                        # Ethereum address to receive payment
-    network: str = "base"                      # Blockchain network
+    network: str = "eip155:8453"               # Blockchain network (CAIP-2 format, Base mainnet)
     description: str = "Payment required..."   # Human-readable description
     mime_type: str = "application/json"        # Expected response type
     max_timeout_seconds: int = 600             # Payment validity timeout
@@ -383,7 +383,7 @@ def create_payment_requirements(
     price: Union[str, int, TokenAmount],  # Price can be Money or TokenAmount
     pay_to_address: str,
     resource: str,
-    network: str = "base",
+    network: str = "eip155:8453",
     description: str = "",
     mime_type: str = "application/json",
     scheme: str = "exact",
@@ -808,7 +808,7 @@ async def handle_payment_request(task: Task, price: str, resource: str):
         price=price,  # Can be "$1.00", 1.00, or TokenAmount
         pay_to_address="0x...",  # Merchant's address
         resource=resource,
-        network="base",
+        network="eip155:8453",
         description="Service payment"
     )
     
@@ -837,7 +837,7 @@ async def handle_payment_submission(task: Task, payment_requirements: PaymentReq
     if not verify_response.is_valid:
         task = utils.record_payment_failure(
             task, "verification_failed", 
-            SettleResponse(success=False, network="base", error_reason=verify_response.invalid_reason)
+            SettleResponse(success=False, network="eip155:8453", error_reason=verify_response.invalid_reason)
         )
         return task
     
@@ -851,7 +851,7 @@ async def handle_payment_submission(task: Task, payment_requirements: PaymentReq
     settle_response_result = SettleResponse(
         success=settle_response.success,
         transaction=settle_response.transaction,
-        network=settle_response.network or "base",
+        network=settle_response.network or "eip155:8453",
         payer=settle_response.payer,
         error_reason=settle_response.error_reason
     )

--- a/python/x402_a2a/core/helpers.py
+++ b/python/x402_a2a/core/helpers.py
@@ -28,7 +28,7 @@ def require_payment(
     price: Union[str, int, TokenAmount],
     pay_to_address: str,
     resource: Optional[str] = None,
-    network: str = "base",
+    network: str = "eip155:8453",
     description: str = "Payment required for this service",
     message: Optional[str] = None
 ) -> x402PaymentRequiredException:
@@ -103,7 +103,7 @@ def paid_service(
     price: Union[str, int, TokenAmount],
     pay_to_address: str,
     resource: Optional[str] = None,
-    network: str = "base",
+    network: str = "eip155:8453",
     description: str = "Payment required for this service"
 ):
     """Decorator to automatically require payment for a function or method.
@@ -152,7 +152,7 @@ def create_tiered_payment_options(
     pay_to_address: str,
     resource: str,
     tiers: Optional[List[dict]] = None,
-    network: str = "base"
+    network: str = "eip155:8453"
 ) -> List[PaymentRequirements]:
     """Create multiple payment options with different tiers/features.
     
@@ -249,7 +249,7 @@ def smart_paid_service(
     price: Union[str, int, TokenAmount],
     pay_to_address: str,
     resource: Optional[str] = None,
-    network: str = "base",
+    network: str = "eip155:8453",
     description: str = "Payment required for this service"
 ):
     """Smart decorator that only requires payment if not already paid.

--- a/python/x402_a2a/core/merchant.py
+++ b/python/x402_a2a/core/merchant.py
@@ -26,7 +26,7 @@ def create_payment_requirements(
     price: Price,
     pay_to_address: str,
     resource: str,
-    network: str = "base",
+    network: str = "eip155:8453",
     description: str = "",
     mime_type: str = "application/json",
     scheme: str = "exact",

--- a/python/x402_a2a/executors/client.py
+++ b/python/x402_a2a/executors/client.py
@@ -104,6 +104,6 @@ class x402ClientExecutor(x402BaseExecutor):
         except Exception as e:
             # Payment processing failed
             from ..types import SettleResponse, x402ErrorCode
-            failure_response = SettleResponse(success=False, network="base", error_reason=f"Payment failed: {e}")
+            failure_response = SettleResponse(success=False, network="eip155:8453", error_reason=f"Payment failed: {e}")
             task = self.utils.record_payment_failure(task, x402ErrorCode.INVALID_SIGNATURE, failure_response)
             await event_queue.enqueue_event(task)

--- a/python/x402_a2a/executors/server.py
+++ b/python/x402_a2a/executors/server.py
@@ -314,7 +314,7 @@ class x402ServerExecutor(x402BaseExecutor, metaclass=ABCMeta):
 
     async def _fail_payment(self, task, error_code: str, error_reason: str, event_queue: EventQueue):
         """Handle payment failure."""
-        failure_response = SettleResponse(success=False, network="base", error_reason=error_reason)
+        failure_response = SettleResponse(success=False, network="eip155:8453", error_reason=error_reason)
         task = self.utils.record_payment_failure(task, error_code, failure_response)
         
 

--- a/python/x402_a2a/types/config.py
+++ b/python/x402_a2a/types/config.py
@@ -35,7 +35,7 @@ class x402ServerConfig(BaseModel):
     """Configuration for how a server expects to be paid"""
     price: Union[str, int, TokenAmount]
     pay_to_address: str
-    network: str = "base"
+    network: str = "eip155:8453"  # Base network in CAIP-2 format
     description: str = "Payment required..."
     mime_type: str = "application/json"
     max_timeout_seconds: int = 600

--- a/python/x402_a2a/types/errors.py
+++ b/python/x402_a2a/types/errors.py
@@ -107,7 +107,7 @@ class x402PaymentRequiredException(x402Error):
         price: Union[str, int, TokenAmount],
         pay_to_address: str,
         resource: str,
-        network: str = "base",
+        network: str = "eip155:8453",
         description: str = "Payment required for this service",
         message: Optional[str] = None
     ) -> 'x402PaymentRequiredException':

--- a/v0.1/schemes/scheme_exact_spark.md
+++ b/v0.1/schemes/scheme_exact_spark.md
@@ -27,7 +27,7 @@ In addition to the standard x402 `PaymentRequirements` fields, the `exact` schem
 ```json
 {
   "scheme": "exact",
-  "network": "spark",
+  "network": "bip122:000000000019d6689c085ae165831e93",
   "maxAmountRequired": "1000",
   "asset": "BTC",
   "payTo": "spark1...",
@@ -58,7 +58,7 @@ Once decoded, the `X-PAYMENT` header is a JSON string with the following propert
 {
   "x402Version": 1,
   "scheme": "exact",
-  "network": "spark",
+  "network": "bip122:000000000019d6689c085ae165831e93",
   "payload": {
     "paymentType": "SPARK" | "LIGHTNING" | "L1",
     "transfer_id": "...",  // Spark (unset if not paid over Spark)
@@ -81,7 +81,7 @@ Once decoded, the `X-PAYMENT-RESPONSE` is a JSON string with the following prope
 ```json
 {
   "success": true | false,
-  "network": "spark",
+  "network": "bip122:000000000019d6689c085ae165831e93",
   "transfer_id": "hex-encoded identifier for the Spark transfer"
 }
 ```

--- a/v0.1/schemes/scheme_exact_uma.md
+++ b/v0.1/schemes/scheme_exact_uma.md
@@ -26,7 +26,7 @@ In addition to the standard x402 `PaymentRequirements` fields, the `exact` schem
 ```json
 {
   "scheme": "exact",
-  "network": "uma",
+  "network": "lightning:mainnet",
   "maxAmountRequired": "1000", // in lowest denomination of asset
   "asset": "USD",
   "payTo": "$receiver@vasp.com",
@@ -50,7 +50,7 @@ Once decoded, the `X-PAYMENT` header is a JSON string with the following propert
 {
  "x402Version": 1,
  "scheme": "exact",
- "network": "uma",
+ "network": "lightning:mainnet",
  "payload": {
    "preimage": "..."
  }
@@ -67,8 +67,8 @@ Once decoded, the `X-PAYMENT-RESPONSE` is a JSON string with the following prope
 
 ```json
 {
- "success": true | false
- "network": "uma"
+ "success": true | false,
+ "network": "lightning:mainnet"
 }
 ```
 

--- a/v0.1/spec.md
+++ b/v0.1/spec.md
@@ -118,7 +118,7 @@ When a Client Agent requests a service, the Merchant Agent determines that payme
             "x402Version": 1,
             "accepts": [{
               "scheme": "exact",
-              "network": "base",
+              "network": "eip155:8453",
               "resource": "https://api.example.com/generate-image",
               "description": "Generate an image",
               "mimeType": "application/json",
@@ -202,7 +202,7 @@ The Agent **MUST** include ALL payment receipts created in the lifetime of a Tas
           "x402.payment.receipts": [{
             "success": true,
             "transaction": "0xabc123...",
-            "network": "base",
+            "network": "eip155:8453",
             "payer": "0xpayerAddress"
           }]
         }
@@ -230,10 +230,17 @@ Sent by the Merchant Agent in the `metadata` of a `Task` to request payment.
 
 Describes a single way a client can pay.
 
+**Note on Network Identifiers:** The `network` field uses the CAIP-2 format (`namespace:reference`) to uniquely identify blockchain networks. Common examples:
+- Ethereum mainnet: `eip155:1`
+- Base: `eip155:8453` 
+- Polygon: `eip155:137`
+- Bitcoin mainnet: `bip122:000000000019d6689c085ae165831e93`
+- Lightning Network: `lightning:mainnet`
+
 | Field | Type | Required | Description |
 | ----- | ----- | ----- | ----- |
 | `scheme` | string | Yes | The payment scheme (e.g., "exact"). |
-| `network` | string | Yes | The blockchain network identifier (e.g., "base"). |
+| `network` | string | Yes | The blockchain network identifier in CAIP-2 format (e.g., "eip155:8453" for Base). |
 | `asset` | string | Yes | The contract address of the token to be paid. |
 | `payTo` | string | Yes | The recipient's wallet address. |
 | `maxAmountRequired` | string | Yes | The required payment amount in the token's smallest unit (e.g., wei). |
@@ -249,7 +256,7 @@ Created by the Signing Service, containing the signed payment authorization.
 | Field | Type | Required | Description |
 | ----- | ----- | ----- | ----- |
 | `x402Version` | number | Yes | The version of the x402 protocol being used. |
-| `network` | string | Yes | The blockchain network for the payment. |
+| `network` | string | Yes | The blockchain network for the payment in CAIP-2 format. |
 | `scheme` | string | Yes | The payment scheme being used. |
 | `payload` | object | Yes | The signed payment details, specific to the scheme. |
 
@@ -262,7 +269,7 @@ Returned by the Merchant Agent in `Task`'s `Message` metadata after a successful
 | `success` | bool | Yes | Status of the transaction settlement |
 | `errorReason` | string | No | Error reason for unsuccessful settlement |
 | `transaction` | string | No | The on-chain transaction hash of the settled payment. Present only if `success` is true. |
-| `network` | string | Yes | The network where the payment was settled. |
+| `network` | string | Yes | The network where the payment was settled in CAIP-2 format. |
 | `payer` | string | No | The payer of the settled transaction |
 
 ## **6\. Metadata and State Management**
@@ -338,7 +345,7 @@ The management of Task states at payment failure is at the discretion of the Mer
         "x402.payment.receipts": [{
             "success": false,
             "errorReason": "Payment authorization was submitted after its 'validBefore' timestamp.",
-            "network": "base",
+            "network": "eip155:8453",
         "transaction": ""
         }]
       }


### PR DESCRIPTION
# Description

While building wallet infrastructure, we've found that using string literals for chain names can get - I'd recommend using the caip2 standard which is standard across all chain types, regardless of the network!