### PR TITLE
feat(spark): add exact payment payload support

### DIFF
--- a/python/examples/adk-demo/client_agent/client_agent.py
+++ b/python/examples/adk-demo/client_agent/client_agent.py
@@ -40,6 +40,7 @@ from google.genai import types
 from ._remote_agent_connection import RemoteAgentConnections, TaskUpdateCallback
 from .wallet import Wallet
 from x402_a2a.core.utils import x402Utils
+from x402_a2a import dump_payment_payload
 from x402_a2a.types import PaymentPayload, x402PaymentRequiredResponse, PaymentStatus
 
 logger = logging.getLogger(__name__)
@@ -155,7 +156,7 @@ You are a master orchestrator agent. Your job is to complete user requests by de
 
             # Sign the payment and prepare the payload for the merchant.
             signed_payload = self.wallet.sign_payment(requirements)
-            message_metadata[self.x402.PAYLOAD_KEY] = signed_payload.model_dump(by_alias=True)
+            message_metadata[self.x402.PAYLOAD_KEY] = dump_payment_payload(signed_payload)
             message_metadata[self.x402.STATUS_KEY] = PaymentStatus.PAYMENT_SUBMITTED.value
             
             # The message text to the merchant is a simple confirmation.

--- a/python/x402_a2a/README.md
+++ b/python/x402_a2a/README.md
@@ -202,13 +202,14 @@ def create_payment_submission_message(
     message_id: Optional[str] = None  # Optional specific message ID
 ) -> Message:
     """Creates correlated payment submission message per spec."""
+    # Use dump_payment_payload to preserve scheme-specific payloads (Spark, etc.).
     return Message(
         task_id=task_id,  # Spec mandates this correlation
         role="user", 
         parts=[{"kind": "text", "text": text}],
         metadata={
             x402Metadata.STATUS_KEY: PaymentStatus.PAYMENT_SUBMITTED.value,
-            x402Metadata.PAYLOAD_KEY: payment_payload.model_dump(by_alias=True)
+            x402Metadata.PAYLOAD_KEY: dump_payment_payload(payment_payload)
         }
     )
 
@@ -564,7 +565,7 @@ class x402Utils:
             task.status.message.metadata = {}
             
         task.status.message.metadata[self.STATUS_KEY] = PaymentStatus.PAYMENT_SUBMITTED.value
-        task.status.message.metadata[self.PAYLOAD_KEY] = payment_payload.model_dump(by_alias=True)
+        task.status.message.metadata[self.PAYLOAD_KEY] = dump_payment_payload(payment_payload)
         # Note: Keep requirements for verification - will be cleaned up after settlement
         return task
 

--- a/python/x402_a2a/__init__.py
+++ b/python/x402_a2a/__init__.py
@@ -67,6 +67,11 @@ from .core import (
     create_payment_requirements,
     process_payment_required,
     process_payment,
+    create_spark_payment_payload,
+    encode_spark_payment_header,
+    decode_spark_payment_header,
+    get_spark_payment_payload,
+    dump_payment_payload,
     verify_payment,
     settle_payment,
     
@@ -143,6 +148,11 @@ __all__ = [
     "create_payment_requirements",
     "process_payment_required", 
     "process_payment",
+    "create_spark_payment_payload",
+    "encode_spark_payment_header",
+    "decode_spark_payment_header",
+    "get_spark_payment_payload",
+    "dump_payment_payload",
     "verify_payment",
     "settle_payment",
     

--- a/python/x402_a2a/core/__init__.py
+++ b/python/x402_a2a/core/__init__.py
@@ -14,7 +14,15 @@
 """Core package exports for x402_a2a."""
 
 from .merchant import create_payment_requirements
-from .wallet import process_payment_required, process_payment
+from .wallet import (
+    process_payment_required,
+    process_payment,
+    create_spark_payment_payload,
+    encode_spark_payment_header,
+    decode_spark_payment_header,
+    get_spark_payment_payload,
+    dump_payment_payload,
+)
 from .protocol import verify_payment, settle_payment
 from .utils import (
     x402Utils,
@@ -38,6 +46,11 @@ __all__ = [
     "create_payment_requirements",
     "process_payment_required",
     "process_payment",
+    "create_spark_payment_payload",
+    "encode_spark_payment_header",
+    "decode_spark_payment_header",
+    "get_spark_payment_payload",
+    "dump_payment_payload",
     
     # Protocol functions
     "verify_payment",

--- a/python/x402_a2a/core/protocol.py
+++ b/python/x402_a2a/core/protocol.py
@@ -22,6 +22,7 @@ from ..types import (
     VerifyResponse,
     FacilitatorClient
 )
+from .wallet import dump_payment_payload
 
 
 async def verify_payment(
@@ -41,9 +42,16 @@ async def verify_payment(
     """
     if facilitator_client is None:
         facilitator_client = FacilitatorClient()
-        
+
+    if payment_payload.network.lower() == "spark":
+        payload_for_facilitator = PaymentPayload.model_construct(
+            **dump_payment_payload(payment_payload)
+        )
+    else:
+        payload_for_facilitator = payment_payload
+
     return await facilitator_client.verify(
-        payment_payload,
+        payload_for_facilitator,
         payment_requirements
     )
 
@@ -65,10 +73,17 @@ async def settle_payment(
     """
     if facilitator_client is None:
         facilitator_client = FacilitatorClient()
-        
+
+    if payment_payload.network.lower() == "spark":
+        payload_for_facilitator = PaymentPayload.model_construct(
+            **dump_payment_payload(payment_payload)
+        )
+    else:
+        payload_for_facilitator = payment_payload
+
     # Call facilitator to settle payment
     settle_response = await facilitator_client.settle(
-        payment_payload,
+        payload_for_facilitator,
         payment_requirements
     )
     

--- a/python/x402_a2a/core/utils.py
+++ b/python/x402_a2a/core/utils.py
@@ -29,13 +29,28 @@ from ..types import (
     TaskStatus
 )
 from a2a.types import TextPart
+from .wallet import dump_payment_payload
 
 
 def _parse_payment_payload(payload_data: dict) -> PaymentPayload:
     """Parse the payment payload using the top-level Pydantic model."""
     # The PaymentPayload model from x402.types is designed to handle the
     # entire structure, including the nested payload based on the scheme.
-    return PaymentPayload.model_validate(payload_data)
+    network = payload_data.get("network")
+    if isinstance(network, str) and network.lower() == "spark":
+        from .wallet import _parse_spark_header_payload  # Lazy import to avoid cycle
+
+        return _parse_spark_header_payload(payload_data)
+
+    payload = PaymentPayload.model_validate(payload_data)
+
+    if payload.scheme == "exact" and not isinstance(payload.payload, ExactPaymentPayload):
+        try:
+            payload.payload = ExactPaymentPayload.model_validate(payload.payload)
+        except Exception:
+            pass
+
+    return payload
 
 
 def create_payment_submission_message(
@@ -60,7 +75,7 @@ def create_payment_submission_message(
         parts=[TextPart(kind="text", text=text)],
         metadata={
             x402Metadata.STATUS_KEY: PaymentStatus.PAYMENT_SUBMITTED.value,
-            x402Metadata.PAYLOAD_KEY: payment_payload.model_dump(by_alias=True)
+            x402Metadata.PAYLOAD_KEY: dump_payment_payload(payment_payload)
         }
     )
 

--- a/python/x402_a2a/core/wallet.py
+++ b/python/x402_a2a/core/wallet.py
@@ -145,13 +145,16 @@ def create_spark_payment_payload(
 
     Args:
         payment_type: Transport used to settle the Spark payment.
-        transfer_id: Spark network transfer identifier (required when payment_type is SPARK).
-        preimage: Lightning preimage proof (required when payment_type is LIGHTNING).
-        txid: Bitcoin L1 transaction id (required when payment_type is L1).
+        transfer_id: Spark network transfer identifier required when
+            payment_type is SPARK.
+        preimage: Lightning preimage proof required when payment_type is
+            LIGHTNING.
+        txid: Bitcoin L1 transaction id required when payment_type is L1.
         x402_version: Protocol version carried in the payload (defaults to 1).
 
     Returns:
-        PaymentPayload ready to embed in `X-PAYMENT` headers or A2A metadata.
+        PaymentPayload ready to embed in `X-PAYMENT` headers or A2A
+        metadata.
     """
 
     spark_payload = ExactSparkPaymentPayload(
@@ -173,7 +176,9 @@ def encode_spark_payment_header(payment_payload: PaymentPayload) -> str:
     """Encode a spark payment payload for use in the ``X-PAYMENT`` header."""
 
     if payment_payload.network.lower() != "spark":
-        raise ValueError("encode_spark_payment_header expects a Spark payment payload")
+        raise ValueError(
+            "encode_spark_payment_header expects a Spark payment payload"
+        )
 
     spark_payload = get_spark_payment_payload(payment_payload)
 
@@ -184,7 +189,11 @@ def encode_spark_payment_header(payment_payload: PaymentPayload) -> str:
         "payload": _spark_payload_to_dict(spark_payload),
     }
 
-    header_json = json.dumps(payload_dict, separators=(",", ":"), sort_keys=True)
+    header_json = json.dumps(
+        payload_dict,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
     return base64.b64encode(header_json.encode("utf-8")).decode("utf-8")
 
 
@@ -214,7 +223,10 @@ def _parse_spark_header_payload(payload_data: dict) -> PaymentPayload:
     payload_dict = payload_data.get("payload", {})
     spark_payload = ExactSparkPaymentPayload.model_validate(payload_dict)
 
-    x402_version = payload_data.get("x402Version", payload_data.get("x402_version", 1))
+    x402_version = payload_data.get(
+        "x402Version",
+        payload_data.get("x402_version", 1),
+    )
     scheme = payload_data.get("scheme", "exact")
 
     return PaymentPayload.model_construct(
@@ -235,7 +247,9 @@ def _spark_payload_to_dict(spark_payload: ExactSparkPaymentPayload) -> dict:
     return payload_dict
 
 
-def get_spark_payment_payload(payment_payload: PaymentPayload) -> ExactSparkPaymentPayload:
+def get_spark_payment_payload(
+    payment_payload: PaymentPayload,
+) -> ExactSparkPaymentPayload:
     """Return the structured Spark payload for a spark network PaymentPayload."""
 
     if payment_payload.network.lower() != "spark":

--- a/python/x402_a2a/core/wallet.py
+++ b/python/x402_a2a/core/wallet.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Payment signing and processing functions."""
+"""Payment signing and processing helpers."""
 
+import base64
+import json
+from binascii import Error as BinasciiError
 from typing import Optional
 from eth_account import Account
 from x402.clients.base import x402Client
@@ -24,7 +27,9 @@ from ..types import (
     x402PaymentRequiredResponse,
     PaymentPayload,
     ExactPaymentPayload,
-    EIP3009Authorization
+    EIP3009Authorization,
+    ExactSparkPaymentPayload,
+    SparkPaymentType
 )
 
 
@@ -46,7 +51,13 @@ def process_payment_required(
     # Use x402Client for payment requirement selection
     client = x402Client(account=account, max_value=max_value)
     selected_requirement = client.select_payment_requirements(payment_required.accepts)
-    
+
+    if selected_requirement.network == "spark":
+        raise NotImplementedError(
+            "Spark payments require an external settlement flow. "
+            "Use create_spark_payment_payload after completing the payment."
+        )
+
     # Create payment payload
     return process_payment(selected_requirement, account, max_value)
 
@@ -67,6 +78,12 @@ def process_payment(
     Returns:
         Signed PaymentPayload object
     """
+    if requirements.network == "spark":
+        raise NotImplementedError(
+            "Spark payments cannot be signed using the EIP-3009 helper. "
+            "Use create_spark_payment_payload instead."
+        )
+
     # TODO: Future x402 library update will provide direct PaymentPayload creation
     # For now, we use the prepare -> sign -> decode pattern
     
@@ -115,3 +132,133 @@ def process_payment(
         payload=exact_payload
     )
 
+
+def create_spark_payment_payload(
+    payment_type: SparkPaymentType,
+    *,
+    transfer_id: Optional[str] = None,
+    preimage: Optional[str] = None,
+    txid: Optional[str] = None,
+    x402_version: int = 1
+) -> PaymentPayload:
+    """Build a Spark payment payload following the exact scheme contract.
+
+    Args:
+        payment_type: Transport used to settle the Spark payment.
+        transfer_id: Spark network transfer identifier (required when payment_type is SPARK).
+        preimage: Lightning preimage proof (required when payment_type is LIGHTNING).
+        txid: Bitcoin L1 transaction id (required when payment_type is L1).
+        x402_version: Protocol version carried in the payload (defaults to 1).
+
+    Returns:
+        PaymentPayload ready to embed in `X-PAYMENT` headers or A2A metadata.
+    """
+
+    spark_payload = ExactSparkPaymentPayload(
+        payment_type=payment_type,
+        transfer_id=transfer_id,
+        preimage=preimage,
+        txid=txid
+    )
+
+    return PaymentPayload.model_construct(
+        x402_version=x402_version,
+        scheme="exact",
+        network="spark",
+        payload=spark_payload
+    )
+
+
+def encode_spark_payment_header(payment_payload: PaymentPayload) -> str:
+    """Encode a spark payment payload for use in the ``X-PAYMENT`` header."""
+
+    if payment_payload.network.lower() != "spark":
+        raise ValueError("encode_spark_payment_header expects a Spark payment payload")
+
+    spark_payload = get_spark_payment_payload(payment_payload)
+
+    payload_dict = {
+        "x402Version": payment_payload.x402_version,
+        "scheme": payment_payload.scheme,
+        "network": payment_payload.network,
+        "payload": _spark_payload_to_dict(spark_payload),
+    }
+
+    header_json = json.dumps(payload_dict, separators=(",", ":"), sort_keys=True)
+    return base64.b64encode(header_json.encode("utf-8")).decode("utf-8")
+
+
+def decode_spark_payment_header(header_value: str) -> PaymentPayload:
+    """Decode an ``X-PAYMENT`` header back into a PaymentPayload instance."""
+
+    try:
+        decoded_bytes = base64.b64decode(header_value)
+    except BinasciiError as exc:
+        raise ValueError("Invalid base64 encoding in X-PAYMENT header") from exc
+
+    try:
+        payload_data = json.loads(decoded_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Decoded X-PAYMENT header is not valid JSON") from exc
+
+    return _parse_spark_header_payload(payload_data)
+
+
+def _parse_spark_header_payload(payload_data: dict) -> PaymentPayload:
+    """Internal helper to reuse parsing logic across spark utilities."""
+
+    network = payload_data.get("network")
+    if not isinstance(network, str) or network.lower() != "spark":
+        raise ValueError("Decoded payload is not targeting the Spark network")
+
+    payload_dict = payload_data.get("payload", {})
+    spark_payload = ExactSparkPaymentPayload.model_validate(payload_dict)
+
+    x402_version = payload_data.get("x402Version", payload_data.get("x402_version", 1))
+    scheme = payload_data.get("scheme", "exact")
+
+    return PaymentPayload.model_construct(
+        x402_version=x402_version,
+        scheme=scheme,
+        network="spark",
+        payload=spark_payload
+    )
+
+
+def _spark_payload_to_dict(spark_payload: ExactSparkPaymentPayload) -> dict:
+    """Serialise the spark payload using the scheme's alias map."""
+
+    payload_dict = spark_payload.model_dump(by_alias=True, exclude_none=True)
+    payment_type = payload_dict.get("paymentType")
+    if isinstance(payment_type, SparkPaymentType):
+        payload_dict["paymentType"] = payment_type.value
+    return payload_dict
+
+
+def get_spark_payment_payload(payment_payload: PaymentPayload) -> ExactSparkPaymentPayload:
+    """Return the structured Spark payload for a spark network PaymentPayload."""
+
+    if payment_payload.network.lower() != "spark":
+        raise ValueError("Payment payload is not targeting the Spark network")
+
+    raw_payload = payment_payload.payload
+    if isinstance(raw_payload, ExactSparkPaymentPayload):
+        return raw_payload
+
+    if isinstance(raw_payload, dict):
+        spark_payload = ExactSparkPaymentPayload.model_validate(raw_payload)
+        return spark_payload
+
+    raise TypeError("Unsupported spark payload type")
+
+
+def dump_payment_payload(payment_payload: PaymentPayload) -> dict:
+    """Serialise PaymentPayload with Spark awareness for metadata transport."""
+
+    data = payment_payload.model_dump(by_alias=True)
+    if payment_payload.network.lower() != "spark":
+        return data
+
+    spark_payload = get_spark_payment_payload(payment_payload)
+    data["payload"] = _spark_payload_to_dict(spark_payload)
+    return data

--- a/python/x402_a2a/tests/test_core.py
+++ b/python/x402_a2a/tests/test_core.py
@@ -24,8 +24,24 @@ from x402_a2a.types import (
     PaymentRequirements,
     VerifyResponse,
     SettleResponse,
+    ExactSparkPaymentPayload,
+    SparkPaymentType,
 )
-from x402_a2a.core.utils import x402Utils
+from x402_a2a.core.utils import x402Utils, create_payment_submission_message
+from x402_a2a.core.protocol import verify_payment, settle_payment
+from x402_a2a.core.wallet import (
+    create_spark_payment_payload,
+    encode_spark_payment_header,
+    decode_spark_payment_header,
+    get_spark_payment_payload,
+    dump_payment_payload,
+)
+
+
+def _spark_hex(seed: int) -> str:
+    """Return a deterministic 32-byte hex string for Spark fixtures."""
+
+    return bytes([seed % 256] * 32).hex()
 
 # --- Fixtures ---
 
@@ -101,7 +117,7 @@ def test_get_payment_payload_from_message(utils, sample_payment_payload):
         role="user",
         parts=[TextPart(text="test")],
         metadata={
-            x402Metadata.PAYLOAD_KEY: sample_payment_payload.model_dump(by_alias=True)
+            x402Metadata.PAYLOAD_KEY: dump_payment_payload(sample_payment_payload)
         }
     )
 
@@ -154,7 +170,7 @@ async def test_server_executor_payment_flow():
         parts=[TextPart(text="test")],
         metadata={
             x402Metadata.STATUS_KEY: PaymentStatus.PAYMENT_SUBMITTED.value,
-            x402Metadata.PAYLOAD_KEY: payment_payload.model_dump(by_alias=True)
+            x402Metadata.PAYLOAD_KEY: dump_payment_payload(payment_payload)
         }
     )
     context.current_task = Task(id="task-123", contextId="context-456", status=TaskStatus(state=TaskState.working), metadata={})
@@ -171,3 +187,118 @@ async def test_server_executor_payment_flow():
     executor.verify_payment.assert_called_once()
     delegate.execute.assert_called_once()
     executor.settle_payment.assert_called_once()
+
+
+@pytest.mark.unit
+def test_exact_spark_payment_payload_validation():
+    """Spark payload enforces transport-specific required fields."""
+
+    spark_payload = ExactSparkPaymentPayload(
+        payment_type=SparkPaymentType.SPARK,
+        transfer_id="abc123"
+    )
+    assert spark_payload.transfer_id == "abc123"
+
+    lightning_payload = ExactSparkPaymentPayload(
+        payment_type=SparkPaymentType.LIGHTNING,
+        preimage="00ff"
+    )
+    assert lightning_payload.preimage == "00ff"
+
+    l1_payload = ExactSparkPaymentPayload(
+        payment_type=SparkPaymentType.L1,
+        txid=_spark_hex(0x42)
+    )
+    assert l1_payload.txid == _spark_hex(0x42)
+
+    with pytest.raises(ValueError):
+        ExactSparkPaymentPayload(payment_type=SparkPaymentType.SPARK)
+
+
+@pytest.mark.unit
+def test_spark_payment_header_roundtrip():
+    """Encoding and decoding the Spark header preserves payload data."""
+
+    payment_payload = create_spark_payment_payload(
+        SparkPaymentType.SPARK,
+        transfer_id="transfer-123"
+    )
+
+    header_value = encode_spark_payment_header(payment_payload)
+    decoded_payload = decode_spark_payment_header(header_value)
+
+    spark_payload = get_spark_payment_payload(decoded_payload)
+    assert spark_payload.transfer_id == "transfer-123"
+
+    dumped_payload = dump_payment_payload(decoded_payload)
+    assert dumped_payload["payload"]["paymentType"] == "SPARK"
+    assert dumped_payload["payload"]["transfer_id"] == "transfer-123"
+    assert "preimage" not in dumped_payload["payload"]
+
+
+@pytest.mark.unit
+def test_spark_payload_preserved_in_message_metadata(utils):
+    """Spark metadata dumped into messages keeps transport-specific details."""
+
+    payment_payload = create_spark_payment_payload(
+        SparkPaymentType.LIGHTNING,
+        preimage=_spark_hex(0x24)
+    )
+
+    message = create_payment_submission_message("task-99", payment_payload)
+    metadata = message.metadata[x402Metadata.PAYLOAD_KEY]
+
+    assert metadata["payload"]["paymentType"] == "LIGHTNING"
+    assert metadata["payload"]["preimage"] == _spark_hex(0x24)
+    assert "transfer_id" not in metadata["payload"]
+
+
+@pytest.mark.asyncio
+async def test_facilitator_preserves_spark_payload(sample_payment_requirements):
+    """Facilitator requests see Spark-specific fields during verify/settle."""
+
+    verify_payload = create_spark_payment_payload(
+        SparkPaymentType.LIGHTNING,
+        preimage=_spark_hex(0x11)
+    )
+    settle_payload = create_spark_payment_payload(
+        SparkPaymentType.SPARK,
+        transfer_id="spark-transfer-001"
+    )
+
+    class RecordingFacilitator:
+        def __init__(self):
+            self.seen_verify = None
+            self.seen_settle = None
+
+        async def verify(self, payload, requirements):
+            self.seen_verify = payload
+            return VerifyResponse(is_valid=True, payer="spark")
+
+        async def settle(self, payload, requirements):
+            self.seen_settle = payload
+            return SettleResponse(success=True, network=requirements.network)
+
+    facilitator = RecordingFacilitator()
+
+    verify_response = await verify_payment(
+        verify_payload,
+        sample_payment_requirements,
+        facilitator_client=facilitator
+    )
+    assert verify_response.is_valid is True
+
+    settle_response = await settle_payment(
+        settle_payload,
+        sample_payment_requirements,
+        facilitator_client=facilitator
+    )
+    assert settle_response.success is True
+
+    assert isinstance(facilitator.seen_verify, PaymentPayload)
+    verify_dump = facilitator.seen_verify.model_dump(by_alias=True)
+    assert verify_dump["payload"]["preimage"] == _spark_hex(0x11)
+
+    assert isinstance(facilitator.seen_settle, PaymentPayload)
+    settle_dump = facilitator.seen_settle.model_dump(by_alias=True)
+    assert settle_dump["payload"]["transfer_id"] == "spark-transfer-001"

--- a/python/x402_a2a/types/__init__.py
+++ b/python/x402_a2a/types/__init__.py
@@ -65,6 +65,10 @@ from .config import (
     x402ExtensionConfig,
     x402ServerConfig
 )
+from .payloads import (
+    ExactSparkPaymentPayload,
+    SparkPaymentType
+)
 from ..extension import (
     get_extension_declaration,
     check_extension_activation,
@@ -115,6 +119,9 @@ __all__ = [
     "X402_EXTENSION_URI",
     "x402ExtensionConfig",
     "x402ServerConfig",
+
+    "ExactSparkPaymentPayload",
+    "SparkPaymentType",
 
     "get_extension_declaration",
     "check_extension_activation", 

--- a/python/x402_a2a/types/payloads.py
+++ b/python/x402_a2a/types/payloads.py
@@ -15,10 +15,11 @@ class SparkPaymentType(str, Enum):
 
 
 class ExactSparkPaymentPayload(BaseModel):
-    """Payload carried in the exact scheme when network == spark.
+    """Payload carried in the exact scheme when ``network == spark``.
 
     The JSON representation maps to the `X-PAYMENT` header body described in
-    `schemes/scheme_exact_spark.md` and mirrors its required/optional fields.
+    `schemes/scheme_exact_spark.md` and mirrors its required and optional
+    fields.
     """
 
     model_config = ConfigDict(
@@ -33,12 +34,24 @@ class ExactSparkPaymentPayload(BaseModel):
 
     @model_validator(mode="after")
     def _validate_required_fields(self) -> "ExactSparkPaymentPayload":
-        """Enforce transport-specific requirements from the scheme specification."""
+        """Enforce scheme-specific transport requirements."""
 
-        if self.payment_type is SparkPaymentType.SPARK and not self.transfer_id:
-            raise ValueError("transfer_id is required when paymentType is SPARK")
-        if self.payment_type is SparkPaymentType.LIGHTNING and not self.preimage:
-            raise ValueError("preimage is required when paymentType is LIGHTNING")
+        if (
+            self.payment_type is SparkPaymentType.SPARK
+            and not self.transfer_id
+        ):
+            raise ValueError(
+                "transfer_id is required when paymentType is SPARK"
+            )
+        if (
+            self.payment_type is SparkPaymentType.LIGHTNING
+            and not self.preimage
+        ):
+            raise ValueError(
+                "preimage is required when paymentType is LIGHTNING"
+            )
         if self.payment_type is SparkPaymentType.L1 and not self.txid:
-            raise ValueError("txid is required when paymentType is L1")
+            raise ValueError(
+                "txid is required when paymentType is L1"
+            )
         return self

--- a/python/x402_a2a/types/payloads.py
+++ b/python/x402_a2a/types/payloads.py
@@ -1,0 +1,44 @@
+"""Scheme-specific payload models for x402 exact payments."""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class SparkPaymentType(str, Enum):
+    """Enumerates transports supported by the Spark exact scheme."""
+
+    SPARK = "SPARK"
+    LIGHTNING = "LIGHTNING"
+    L1 = "L1"
+
+
+class ExactSparkPaymentPayload(BaseModel):
+    """Payload carried in the exact scheme when network == spark.
+
+    The JSON representation maps to the `X-PAYMENT` header body described in
+    `schemes/scheme_exact_spark.md` and mirrors its required/optional fields.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    payment_type: SparkPaymentType = Field(alias="paymentType")
+    transfer_id: Optional[str] = Field(default=None, alias="transfer_id")
+    preimage: Optional[str] = None
+    txid: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_required_fields(self) -> "ExactSparkPaymentPayload":
+        """Enforce transport-specific requirements from the scheme specification."""
+
+        if self.payment_type is SparkPaymentType.SPARK and not self.transfer_id:
+            raise ValueError("transfer_id is required when paymentType is SPARK")
+        if self.payment_type is SparkPaymentType.LIGHTNING and not self.preimage:
+            raise ValueError("preimage is required when paymentType is LIGHTNING")
+        if self.payment_type is SparkPaymentType.L1 and not self.txid:
+            raise ValueError("txid is required when paymentType is L1")
+        return self


### PR DESCRIPTION
# Description

This PR finishes the Spark exact-flow plumbing by adding a dedicated payload model and helper functions in the core library, updating the demo facilitator/client to follow the new serialization path, and tightening docstrings to comply with Google’s style guide.

- Added Spark payload helpers (`ExactSparkPaymentPayload`, create/encode/decode/dump helpers) so transport-specific fields persist exactly as the scheme expects.
- Routed facilitator utilities, core helpers, and the demo client through `dump_payment_payload`, keeping Spark transfer IDs, preimages, and txids intact.
- Updated the mock facilitator to understand Spark payloads and echo meaningful payer/transaction data for both verify and settle flows.
- Added unit coverage in `python/x402_a2a/tests/test_core.py` to lock in Spark payload serialization/deserialization behavior.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-agentic-commerce/a2a-x402?tab=contributing-ov-file#how-to-contribute).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #35 🦕

**Testing**

PYTHONPATH=python pytest python/x402_a2a/tests -q

**Conformance Impact**

Spark exact serialization now flows through `dump_payment_payload` (`python/x402_a2a/core/wallet.py`, `python/x402_a2a/types/payloads.py`); payload shape remains aligned with `schemes/scheme_exact_spark.md`, so no spec updates beyond the README pointer were required.

**Known Issues**

`PaymentPayload.model_dump` still emits the upstream “UnexpectedValue” warning when rehydrating Spark payloads because the x402 library only models the EVM exact payload today; this change works around the warning without altering upstream typing.
