### PR TITLE
chore: skip release-please in fork

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'google-agentic-commerce'
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
Skips `release-please` GH action in forks.

An alternative approach would be to do something like:

```diff
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,9 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'google-agentic-commerce'
+    env:
+      HAS_BOT_TOKEN: ${{ secrets.BOT_TOKEN != '' }}
+    if: env.HAS_BOT_TOKEN == 'true'
     steps:
       - uses: googleapis/release-please-action@v4
         with:
```