### PR TITLE
chore: downgrade required python version of core library to >= 3.10

### DIFF
--- a/python/x402_a2a/pyproject.toml
+++ b/python/x402_a2a/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Coinbase Developer Platform", email = "x402@coinbase.com" },
     { name = "Google A2A", email = "a2a@google.com" }
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 keywords = ["a2a", "x402", "payments", "ethereum", "coinbase", "google"]
 dependencies = [
     "a2a-sdk",  # For A2A protocol integration
@@ -55,4 +55,4 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"


### PR DESCRIPTION
Downgrades the minimum Python version requirement for the x402_a2a core library from Python 3.11 to Python 3.10 to align with the Python version requirements from the x402 and a2a-sdk repositories, both of which support Python 3.10+.