### PR TITLE
chore: update .gitignore to include common AI agent markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ __pycache__/
 *.pyo
 *.pyd
 
-# Claude Code files
-claude.md
+# Coding Agent MD files
+AGENTS.md
+CLAUDE.md
+GEMINI.md


### PR DESCRIPTION
This PR updates the .gitignore file to consistently ignore common AI agent markdown files (AGENTS.md, CLAUDE.md, GEMINI.md) for a unified approach to managing agent-specific documentation and a cleaner repository.