### PR TITLE
fix: make resource required in require_payment()

### DIFF
--- a/python/x402_a2a/src/x402_a2a/core/helpers.py
+++ b/python/x402_a2a/src/x402_a2a/core/helpers.py
@@ -23,7 +23,7 @@ from .merchant import create_payment_requirements
 def require_payment(
     price: Union[str, int, TokenAmount],
     pay_to_address: str,
-    resource: Optional[str] = None,
+    resource: str,
     network: str = "base",
     description: str = "Payment required for this service",
     message: Optional[str] = None,
@@ -35,7 +35,7 @@ def require_payment(
     Args:
         price: Payment amount (e.g., "$1.00", 1.00, TokenAmount)
         pay_to_address: Ethereum address to receive payment
-        resource: Resource identifier (auto-generated if None)
+        resource: Resource identifier (e.g., "/api/generate")
         network: Blockchain network (default: "base")
         description: Human-readable description
         message: Exception message (default: uses description)
@@ -56,7 +56,7 @@ def require_payment(
     return x402PaymentRequiredException.for_service(
         price=price,
         pay_to_address=pay_to_address,
-        resource=resource or "/service",
+        resource=resource,
         network=network,
         description=description,
         message=message,


### PR DESCRIPTION
Fixes #42.

`require_payment()` had `resource` as optional with a fallback to `"/service"`, which is an invalid resource that facilitators reject. This makes `resource` a required parameter so callers get a clear error at call time instead of a confusing rejection downstream.

The `paid_service` and `smart_paid_service` decorators already derive resource from the function name, so they're unaffected — they pass an explicit resource to `require_payment()`.