### PR TITLE
docs: add AP2 protocol reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This design provides both flexibility and ease of use, allowing developers to ei
 *   **[Python Examples](python/examples/)**: The directory containing demonstration applications for the Python implementation.
 *   **[A2A Protocol](https://github.com/a2aproject/a2a-python)**: The core agent-to-agent protocol.
 *   **[x402 Protocol](https://x402.gitbook.io/x402)**: The underlying payment protocol.
+*   **[AP2 Protocol](https://github.com/google-agentic-commerce/AP2)**: The Agent Payments Protocol.
 
 ## 🤝 **Contributing**
 


### PR DESCRIPTION
This PR adds the missing AP2 Protocol reference link to the Learn More section of the README.md.