### PR TITLE
feat(executor): SpendingPolicy hook for spending limits + circuit breakers (closes #60)

### DIFF
--- a/python/x402_a2a/src/x402_a2a/core/__init__.py
+++ b/python/x402_a2a/src/x402_a2a/core/__init__.py
@@ -26,6 +26,12 @@ from .helpers import (
     check_payment_context,
 )
 from .agent import create_x402_agent_card
+from .policy import (
+    SpendingPolicy,
+    NoOpSpendingPolicy,
+    BoundedSpendPolicy,
+    PolicyDecision,
+)
 
 __all__ = [
     # Core merchant/wallet functions
@@ -48,4 +54,9 @@ __all__ = [
     "check_payment_context",
     # Agent utilities
     "create_x402_agent_card",
+    # Spending policy hooks (issue #60)
+    "SpendingPolicy",
+    "NoOpSpendingPolicy",
+    "BoundedSpendPolicy",
+    "PolicyDecision",
 ]

--- a/python/x402_a2a/src/x402_a2a/core/policy.py
+++ b/python/x402_a2a/src/x402_a2a/core/policy.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Spending policy hooks for x402ServerExecutor.
+
+Addresses the security gaps identified in
+https://github.com/google-agentic-commerce/a2a-x402/issues/60 — specifically
+per-agent spending limits and circuit breakers. The default executor wires a
+`NoOpSpendingPolicy` so behavior is unchanged unless a policy is supplied.
+
+Two abstractions:
+
+  * `SpendingPolicy` — abstract base. Implement `check` to reject a payment
+    before settlement, and `record_settlement` to update internal state from
+    the settlement outcome.
+  * `BoundedSpendPolicy` — reference in-memory implementation with per-tx,
+    hourly, and daily caps plus a consecutive-failure circuit breaker.
+
+`BoundedSpendPolicy` is intentionally simple: a sliding window of timestamps
+keyed by `pay_to`, suitable for single-process agents. Production
+deployments with multiple workers should subclass `SpendingPolicy` against
+shared state (Redis, a DB, etc.) — the abstract base does not constrain
+the backend.
+"""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, Optional
+
+from ..types import PaymentPayload, PaymentRequirements
+
+
+@dataclass
+class PolicyDecision:
+    """Outcome of a `SpendingPolicy.check`.
+
+    `allowed=True` lets settlement proceed. `allowed=False` short-circuits
+    payment with `reason` surfaced to the caller via `error_reason` on the
+    failure response.
+    """
+
+    allowed: bool
+    reason: Optional[str] = None
+
+    @classmethod
+    def allow(cls) -> "PolicyDecision":
+        return cls(allowed=True)
+
+    @classmethod
+    def deny(cls, reason: str) -> "PolicyDecision":
+        return cls(allowed=False, reason=reason)
+
+
+class SpendingPolicy(ABC):
+    """Pre-settlement policy hook.
+
+    The executor calls `check` after payment payload + requirements are
+    resolved but before `verify_payment` / `settle_payment`. A denied
+    decision aborts the flow without touching the facilitator. After a
+    settlement attempt completes, `record_settlement` is invoked with the
+    outcome so stateful policies (rate limits, circuit breakers) can update.
+    """
+
+    @abstractmethod
+    def check(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+    ) -> PolicyDecision:
+        """Return `PolicyDecision.allow()` to proceed, or `deny(...)` to abort."""
+
+    @abstractmethod
+    def record_settlement(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+        success: bool,
+    ) -> None:
+        """Record the outcome of a settlement attempt for stateful policies."""
+
+
+class NoOpSpendingPolicy(SpendingPolicy):
+    """Default policy: allow every payment, record nothing.
+
+    Wired automatically when no policy is supplied so existing executors
+    are behavior-preserving.
+    """
+
+    def check(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+    ) -> PolicyDecision:
+        return PolicyDecision.allow()
+
+    def record_settlement(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+        success: bool,
+    ) -> None:
+        return None
+
+
+def _amount_int(requirements: PaymentRequirements) -> int:
+    """Best-effort integer parse of a `max_amount_required` string."""
+    raw = requirements.max_amount_required
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+@dataclass
+class _RecipientWindow:
+    """Per-`pay_to` sliding-window state used by `BoundedSpendPolicy`."""
+
+    settled: Deque[tuple[float, int]] = field(default_factory=deque)
+    consecutive_failures: int = 0
+    circuit_open_until: float = 0.0
+
+
+class BoundedSpendPolicy(SpendingPolicy):
+    """In-memory spending caps + consecutive-failure circuit breaker.
+
+    Caps are applied per recipient (`PaymentRequirements.pay_to`) and are
+    expressed in the smallest unit of the asset (matching the on-wire
+    `max_amount_required` representation). Pass `None` for any cap to
+    disable that bound.
+
+    Args:
+        per_tx_max: Maximum amount allowed in a single payment. Denied at
+            `check`; the settlement is never attempted.
+        hourly_max: Sum of amounts settled in the last 3600s. Includes
+            the current payment when checking.
+        daily_max: Sum of amounts settled in the last 86400s. Includes
+            the current payment when checking.
+        circuit_failure_threshold: Open the breaker after this many
+            consecutive failed settlements per recipient.
+        circuit_cooldown_seconds: How long the breaker stays open before
+            allowing another attempt.
+        clock: Override for testing. Defaults to `time.time`.
+    """
+
+    def __init__(
+        self,
+        per_tx_max: Optional[int] = None,
+        hourly_max: Optional[int] = None,
+        daily_max: Optional[int] = None,
+        circuit_failure_threshold: int = 5,
+        circuit_cooldown_seconds: float = 60.0,
+        clock=time.time,
+    ):
+        self.per_tx_max = per_tx_max
+        self.hourly_max = hourly_max
+        self.daily_max = daily_max
+        self.circuit_failure_threshold = circuit_failure_threshold
+        self.circuit_cooldown_seconds = circuit_cooldown_seconds
+        self._clock = clock
+        self._state: Dict[str, _RecipientWindow] = defaultdict(_RecipientWindow)
+
+    def _window(self, key: str) -> _RecipientWindow:
+        return self._state[key]
+
+    def _prune(self, window: _RecipientWindow, now: float, horizon: float) -> None:
+        while window.settled and (now - window.settled[0][0]) > horizon:
+            window.settled.popleft()
+
+    def _sum_within(self, window: _RecipientWindow, now: float, horizon: float) -> int:
+        total = 0
+        for ts, amount in window.settled:
+            if (now - ts) <= horizon:
+                total += amount
+        return total
+
+    def check(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+    ) -> PolicyDecision:
+        amount = _amount_int(requirements)
+        recipient = requirements.pay_to or "<unknown>"
+        now = self._clock()
+        window = self._window(recipient)
+
+        if window.circuit_open_until and now < window.circuit_open_until:
+            return PolicyDecision.deny(
+                f"circuit breaker open for {recipient} "
+                f"(retry after {window.circuit_open_until - now:.1f}s)"
+            )
+
+        if self.per_tx_max is not None and amount > self.per_tx_max:
+            return PolicyDecision.deny(
+                f"per-tx cap exceeded: {amount} > {self.per_tx_max}"
+            )
+
+        if self.hourly_max is not None:
+            self._prune(window, now, 86400.0)
+            spent_hour = self._sum_within(window, now, 3600.0)
+            if (spent_hour + amount) > self.hourly_max:
+                return PolicyDecision.deny(
+                    f"hourly cap exceeded: {spent_hour + amount} > {self.hourly_max}"
+                )
+
+        if self.daily_max is not None:
+            self._prune(window, now, 86400.0)
+            spent_day = self._sum_within(window, now, 86400.0)
+            if (spent_day + amount) > self.daily_max:
+                return PolicyDecision.deny(
+                    f"daily cap exceeded: {spent_day + amount} > {self.daily_max}"
+                )
+
+        return PolicyDecision.allow()
+
+    def record_settlement(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+        success: bool,
+    ) -> None:
+        recipient = requirements.pay_to or "<unknown>"
+        amount = _amount_int(requirements)
+        now = self._clock()
+        window = self._window(recipient)
+
+        if success:
+            window.settled.append((now, amount))
+            window.consecutive_failures = 0
+            window.circuit_open_until = 0.0
+        else:
+            window.consecutive_failures += 1
+            if window.consecutive_failures >= self.circuit_failure_threshold:
+                window.circuit_open_until = now + self.circuit_cooldown_seconds

--- a/python/x402_a2a/src/x402_a2a/executors/server.py
+++ b/python/x402_a2a/src/x402_a2a/executors/server.py
@@ -20,6 +20,7 @@ from typing import Optional, Dict, List
 from a2a.server.tasks import TaskUpdater
 
 from .base import x402BaseExecutor
+from ..core.policy import NoOpSpendingPolicy, SpendingPolicy
 from ..types import (
     AgentExecutor,
     RequestContext,
@@ -64,15 +65,24 @@ class x402ServerExecutor(x402BaseExecutor, metaclass=ABCMeta):
         self,
         delegate: AgentExecutor,
         config: x402ExtensionConfig,
+        policy: Optional[SpendingPolicy] = None,
     ):
         """Initialize server executor.
 
         Args:
             delegate: Underlying agent executor for business logic
             config: x402 extension configuration
+            policy: Optional spending policy invoked before settlement.
+                Defaults to ``NoOpSpendingPolicy`` so behavior is
+                unchanged unless a policy is supplied. See
+                :class:`x402_a2a.core.policy.SpendingPolicy` for the hook
+                contract and ``BoundedSpendPolicy`` for a reference
+                in-memory implementation. Addresses
+                https://github.com/google-agentic-commerce/a2a-x402/issues/60.
         """
         super().__init__(delegate, config)
         self._payment_requirements_store: Dict[str, List[PaymentRequirements]] = {}
+        self._policy: SpendingPolicy = policy or NoOpSpendingPolicy()
 
     @abstractmethod
     async def verify_payment(
@@ -181,6 +191,16 @@ class x402ServerExecutor(x402BaseExecutor, metaclass=ABCMeta):
             f"Retrieved payment requirements: {payment_requirements.model_dump_json(indent=2)}"
         )
 
+        decision = self._policy.check(payment_payload, payment_requirements)
+        if not decision.allowed:
+            logger.warning(f"Payment rejected by spending policy: {decision.reason}")
+            return await self._fail_payment(
+                task,
+                x402ErrorCode.POLICY_REJECTED,
+                decision.reason or "Spending policy rejected payment",
+                event_queue,
+            )
+
         try:
             logger.info("Calling self.verify_payment...")
             verify_response = await self.verify_payment(
@@ -263,10 +283,16 @@ class x402ServerExecutor(x402BaseExecutor, metaclass=ABCMeta):
                 )
 
                 self._payment_requirements_store.pop(task.id, None)
+            self._policy.record_settlement(
+                payment_payload, payment_requirements, settle_response.success
+            )
             await event_queue.enqueue_event(task)
             logger.info("Settlement processing finished.")
         except Exception as e:
             logger.error(f"Exception during settlement: {e}", exc_info=True)
+            self._policy.record_settlement(
+                payment_payload, payment_requirements, success=False
+            )
             await self._fail_payment(
                 task,
                 x402ErrorCode.SETTLEMENT_FAILED,

--- a/python/x402_a2a/src/x402_a2a/types/errors.py
+++ b/python/x402_a2a/src/x402_a2a/types/errors.py
@@ -155,6 +155,7 @@ class x402ErrorCode:
     NETWORK_MISMATCH = "NETWORK_MISMATCH"
     INVALID_AMOUNT = "INVALID_AMOUNT"
     SETTLEMENT_FAILED = "SETTLEMENT_FAILED"
+    POLICY_REJECTED = "POLICY_REJECTED"
 
     @classmethod
     def get_all_codes(cls) -> list[str]:
@@ -167,6 +168,7 @@ class x402ErrorCode:
             cls.NETWORK_MISMATCH,
             cls.INVALID_AMOUNT,
             cls.SETTLEMENT_FAILED,
+            cls.POLICY_REJECTED,
         ]
 
 

--- a/python/x402_a2a/tests/test_policy.py
+++ b/python/x402_a2a/tests/test_policy.py
@@ -1,0 +1,313 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the spending policy hook (issue #60)."""
+
+import pytest
+
+from x402_a2a.core.policy import (
+    BoundedSpendPolicy,
+    NoOpSpendingPolicy,
+    PolicyDecision,
+    SpendingPolicy,
+)
+from x402_a2a.types import PaymentPayload, PaymentRequirements, x402ErrorCode
+
+
+def _requirements(amount: str = "100", pay_to: str = "0xabc") -> PaymentRequirements:
+    return PaymentRequirements(
+        scheme="exact",
+        network="base-sepolia",
+        pay_to=pay_to,
+        max_amount_required=amount,
+        asset="0x456",
+        description="test",
+        resource="/test",
+        mime_type="application/json",
+        max_timeout_seconds=600,
+    )
+
+
+def _payload() -> PaymentPayload:
+    return PaymentPayload(
+        x402_version=1,
+        scheme="exact",
+        network="base-sepolia",
+        payload={
+            "signature": "0xsig",
+            "authorization": {
+                "from": "0xpayer",
+                "to": "0xabc",
+                "value": "100",
+                "valid_after": "0",
+                "valid_before": "9999999999",
+                "nonce": "0xnonce",
+            },
+        },
+    )
+
+
+class _FakeClock:
+    def __init__(self, t: float = 1_000_000.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def test_policy_decision_allow_and_deny():
+    allow = PolicyDecision.allow()
+    assert allow.allowed is True
+    assert allow.reason is None
+
+    deny = PolicyDecision.deny("nope")
+    assert deny.allowed is False
+    assert deny.reason == "nope"
+
+
+def test_noop_policy_allows_everything_and_records_nothing():
+    policy = NoOpSpendingPolicy()
+    decision = policy.check(_payload(), _requirements("999999999"))
+    assert decision.allowed is True
+    assert isinstance(policy, SpendingPolicy)
+    policy.record_settlement(_payload(), _requirements(), success=False)
+
+
+def test_bounded_per_tx_cap_rejects_oversized_payment():
+    policy = BoundedSpendPolicy(per_tx_max=500)
+    decision = policy.check(_payload(), _requirements("501"))
+    assert decision.allowed is False
+    assert "per-tx cap exceeded" in (decision.reason or "")
+
+
+def test_bounded_per_tx_cap_allows_at_cap():
+    policy = BoundedSpendPolicy(per_tx_max=500)
+    decision = policy.check(_payload(), _requirements("500"))
+    assert decision.allowed is True
+
+
+def test_bounded_hourly_cap_rejects_after_window_fills():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(hourly_max=1000, clock=clock)
+
+    for _ in range(10):
+        assert policy.check(_payload(), _requirements("100")).allowed is True
+        policy.record_settlement(_payload(), _requirements("100"), success=True)
+
+    decision = policy.check(_payload(), _requirements("1"))
+    assert decision.allowed is False
+    assert "hourly cap exceeded" in (decision.reason or "")
+
+
+def test_bounded_hourly_cap_window_slides():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(hourly_max=1000, clock=clock)
+
+    for _ in range(10):
+        policy.record_settlement(_payload(), _requirements("100"), success=True)
+
+    assert policy.check(_payload(), _requirements("1")).allowed is False
+
+    clock.advance(3601.0)
+    assert policy.check(_payload(), _requirements("100")).allowed is True
+
+
+def test_bounded_daily_cap_independent_of_hourly():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(hourly_max=10_000, daily_max=1_000, clock=clock)
+
+    policy.record_settlement(_payload(), _requirements("900"), success=True)
+    decision = policy.check(_payload(), _requirements("200"))
+    assert decision.allowed is False
+    assert "daily cap exceeded" in (decision.reason or "")
+
+
+def test_bounded_caps_are_per_recipient():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(hourly_max=500, clock=clock)
+
+    for _ in range(5):
+        policy.record_settlement(
+            _payload(), _requirements("100", pay_to="0xrecipientA"), success=True
+        )
+
+    assert (
+        policy.check(_payload(), _requirements("100", pay_to="0xrecipientA")).allowed
+        is False
+    )
+    assert (
+        policy.check(_payload(), _requirements("100", pay_to="0xrecipientB")).allowed
+        is True
+    )
+
+
+def test_circuit_breaker_opens_after_threshold():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(
+        circuit_failure_threshold=3,
+        circuit_cooldown_seconds=30.0,
+        clock=clock,
+    )
+
+    for _ in range(3):
+        assert policy.check(_payload(), _requirements()).allowed is True
+        policy.record_settlement(_payload(), _requirements(), success=False)
+
+    decision = policy.check(_payload(), _requirements())
+    assert decision.allowed is False
+    assert "circuit breaker open" in (decision.reason or "")
+
+
+def test_circuit_breaker_closes_after_cooldown():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(
+        circuit_failure_threshold=2,
+        circuit_cooldown_seconds=30.0,
+        clock=clock,
+    )
+
+    for _ in range(2):
+        policy.record_settlement(_payload(), _requirements(), success=False)
+
+    assert policy.check(_payload(), _requirements()).allowed is False
+
+    clock.advance(31.0)
+    assert policy.check(_payload(), _requirements()).allowed is True
+
+
+def test_circuit_breaker_resets_on_successful_settlement():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(
+        circuit_failure_threshold=3,
+        circuit_cooldown_seconds=30.0,
+        clock=clock,
+    )
+
+    for _ in range(2):
+        policy.record_settlement(_payload(), _requirements(), success=False)
+    policy.record_settlement(_payload(), _requirements(), success=True)
+
+    for _ in range(2):
+        assert policy.check(_payload(), _requirements()).allowed is True
+        policy.record_settlement(_payload(), _requirements(), success=False)
+
+    assert policy.check(_payload(), _requirements()).allowed is True
+
+
+def test_failed_settlement_does_not_consume_budget():
+    clock = _FakeClock()
+    policy = BoundedSpendPolicy(hourly_max=100, clock=clock)
+
+    policy.record_settlement(_payload(), _requirements("100"), success=False)
+
+    decision = policy.check(_payload(), _requirements("100"))
+    assert decision.allowed is True
+
+
+def test_disabled_caps_allow_everything():
+    policy = BoundedSpendPolicy()
+    huge = _requirements("999999999999999999999999")
+    assert policy.check(_payload(), huge).allowed is True
+
+
+def test_policy_rejected_error_code_registered():
+    assert x402ErrorCode.POLICY_REJECTED == "POLICY_REJECTED"
+    assert x402ErrorCode.POLICY_REJECTED in x402ErrorCode.get_all_codes()
+
+
+def test_subclass_can_replace_storage_backend():
+    class StatelessAllowAll(SpendingPolicy):
+        def check(self, payload, requirements):
+            return PolicyDecision.allow()
+
+        def record_settlement(self, payload, requirements, success):
+            return None
+
+    p = StatelessAllowAll()
+    assert p.check(_payload(), _requirements("9999999")).allowed is True
+
+
+@pytest.mark.asyncio
+async def test_executor_short_circuits_on_policy_denial():
+    """End-to-end: a denying policy aborts before verify/settle are called."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from a2a.types import Message, Task, TaskState, TaskStatus, TextPart
+
+    from x402_a2a.executors.server import x402ServerExecutor
+    from x402_a2a.types import (
+        PaymentStatus,
+        SettleResponse,
+        VerifyResponse,
+        x402Metadata,
+    )
+
+    class _DenyAll(SpendingPolicy):
+        def __init__(self):
+            self.records = []
+
+        def check(self, payload, requirements):
+            return PolicyDecision.deny("budget exhausted")
+
+        def record_settlement(self, payload, requirements, success):
+            self.records.append(success)
+
+    class _Concrete(x402ServerExecutor):
+        async def verify_payment(self, payload, requirements):
+            return VerifyResponse(is_valid=True, payer="0xpayer")
+
+        async def settle_payment(self, payload, requirements):
+            return SettleResponse(success=True)
+
+    delegate = AsyncMock()
+    policy = _DenyAll()
+    executor = _Concrete(delegate=delegate, config=MagicMock(), policy=policy)
+    executor.verify_payment = AsyncMock(
+        return_value=VerifyResponse(is_valid=True, payer="0xpayer")
+    )
+    executor.settle_payment = AsyncMock(return_value=SettleResponse(success=True))
+
+    context = MagicMock()
+    context.task_id = "task-deny"
+    context.context_id = "context-deny"
+    event_queue = AsyncMock()
+
+    payment_payload = _payload()
+    context.message = Message(
+        messageId="msg-1",
+        role="user",
+        parts=[TextPart(text="test")],
+        metadata={
+            x402Metadata.STATUS_KEY: PaymentStatus.PAYMENT_SUBMITTED.value,
+            x402Metadata.PAYLOAD_KEY: payment_payload.model_dump(by_alias=True),
+        },
+    )
+    context.current_task = Task(
+        id="task-deny",
+        contextId="context-deny",
+        status=TaskStatus(state=TaskState.working),
+        metadata={},
+    )
+
+    executor._payment_requirements_store[context.current_task.id] = [_requirements()]
+
+    await executor.execute(context, event_queue)
+
+    executor.verify_payment.assert_not_called()
+    executor.settle_payment.assert_not_called()
+    delegate.execute.assert_not_called()
+    assert event_queue.enqueue_event.await_count >= 1
+    assert policy.records == []


### PR DESCRIPTION
## Summary

Closes #60. Adds a pre-settlement `SpendingPolicy` hook to `x402ServerExecutor` so deployers can enforce per-agent spending caps and trip a circuit breaker on consecutive settlement failures, without forking the executor.

The default is a `NoOpSpendingPolicy` so every existing user is behavior-preserving — opt in by passing a policy.

```python
from x402_a2a.core.policy import BoundedSpendPolicy
from x402_a2a.executors.server import x402ServerExecutor

policy = BoundedSpendPolicy(
    per_tx_max=10_000_000,        # 10 USDC (smallest unit)
    hourly_max=100_000_000,       # 100 USDC / hour
    daily_max=500_000_000,        # 500 USDC / day
    circuit_failure_threshold=5,
    circuit_cooldown_seconds=60.0,
)

server = MyExecutor(delegate, config, policy=policy)
```

## What changes

**New `core/policy.py`** (~190 LoC)
- `SpendingPolicy` ABC: `check(payload, requirements) -> PolicyDecision` (allow / deny + reason) and `record_settlement(payload, requirements, success)`.
- `NoOpSpendingPolicy`: default; allows every payment, records nothing. Wired automatically when no policy is supplied.
- `BoundedSpendPolicy`: reference in-memory implementation with per-tx, hourly, and daily caps and a consecutive-failure circuit breaker. All limits are per-recipient (`PaymentRequirements.pay_to`). Pluggable `clock` parameter so tests don't have to wait an hour.

The abstract base intentionally does **not** constrain the backend — multi-worker production deployments can subclass against Redis / a DB without touching the reference impl. `BoundedSpendPolicy` is documented as suitable for single-process agents.

**`x402ServerExecutor`** (`executors/server.py`)
- Optional `policy: Optional[SpendingPolicy] = None` constructor arg, defaulting to `NoOpSpendingPolicy()`.
- In `_process_paid_request`: after requirements are resolved but before `verify_payment`, call `self._policy.check(...)`. If denied, short-circuit via `_fail_payment` with `POLICY_REJECTED` — the facilitator is never touched.
- `self._policy.record_settlement(...)` is invoked on both the normal settlement path (success or merchant-side failure) and the settlement-exception path, so circuit-breaker state remains accurate even when settlement throws.

**`x402ErrorCode.POLICY_REJECTED`** added to the standard error code set and to `get_all_codes()` so policy denials surface a stable, distinguishable failure code clients can branch on.

## Why this hook, here

Issue #60 lists four security gaps. This PR addresses (1) per-agent spending limits and (3) circuit breaker for facilitator failures directly, in the smallest possible blast radius:

- The hook lives **before** `verify_payment`, so a rejection costs nothing on the facilitator side.
- The hook is **post-requirements-lookup**, so the policy sees the full `PaymentRequirements` (recipient, amount, network) and can make per-recipient decisions.
- The contract is intentionally narrow: two methods, no opinion on how state is stored, no opinion on what \"a budget\" means beyond per-tx / hourly / daily totals. The reference impl is a starting point, not a mandate.

(Gaps (2) idempotency for retries and (4) cross-agent provenance tracking are out of scope here. They warrant their own designs — happy to follow up in separate PRs if maintainers agree on the direction.)

## Backwards compatibility

The constructor change is purely additive (new keyword arg with a default). No existing call site changes. With no policy supplied, the executor calls `NoOpSpendingPolicy.check()` (returns `allow()`) and `NoOpSpendingPolicy.record_settlement()` (no-op) — net cost is two cheap virtual calls per paid request.

## Tests (16 new; full suite 19/19 green)

```
tests/test_policy.py::test_policy_decision_allow_and_deny PASSED
tests/test_policy.py::test_noop_policy_allows_everything_and_records_nothing PASSED
tests/test_policy.py::test_bounded_per_tx_cap_rejects_oversized_payment PASSED
tests/test_policy.py::test_bounded_per_tx_cap_allows_at_cap PASSED
tests/test_policy.py::test_bounded_hourly_cap_rejects_after_window_fills PASSED
tests/test_policy.py::test_bounded_hourly_cap_window_slides PASSED
tests/test_policy.py::test_bounded_daily_cap_independent_of_hourly PASSED
tests/test_policy.py::test_bounded_caps_are_per_recipient PASSED
tests/test_policy.py::test_circuit_breaker_opens_after_threshold PASSED
tests/test_policy.py::test_circuit_breaker_closes_after_cooldown PASSED
tests/test_policy.py::test_circuit_breaker_resets_on_successful_settlement PASSED
tests/test_policy.py::test_failed_settlement_does_not_consume_budget PASSED
tests/test_policy.py::test_disabled_caps_allow_everything PASSED
tests/test_policy.py::test_policy_rejected_error_code_registered PASSED
tests/test_policy.py::test_subclass_can_replace_storage_backend PASSED
tests/test_policy.py::test_executor_short_circuits_on_policy_denial PASSED
```

The integration test asserts that when a policy denies, `verify_payment`, `settle_payment`, and the delegate's `execute` are **not** called and the failure event is enqueued — the contract that matters for keeping money safe.

## Out of scope

- Idempotency / replay protection (issue #60 gap 2). Belongs in `_process_paid_request` near the requirements store but is independent design work.
- Provenance tracking across A2A chains (issue #60 gap 4). Crosses message-boundary concerns.
- Refactoring the executor into the more granular `before_execute` / `after_execute` hooks proposed in #40. That's a larger interface change; this PR doesn't preempt it. The `SpendingPolicy` here would compose naturally with #40's hook framework when it lands.

## Test plan

- [x] `pytest tests/test_policy.py` (16/16)
- [x] `pytest tests/` (19/19, full suite)
- [x] confirm default behavior preserved when `policy=None`
- [x] confirm denial path bypasses verify/settle
- [ ] CI

---

Submitted from kcolbchain (`abhi@kcolbchain.com`). We've been working in adjacent territory — `kcolbchain/switchboard` ships its own gas budget tracker / nonce-safe payment middleware, which is what made the gap in #60 jump out. Happy to iterate on the API shape if there's a different design direction the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)