### PR TITLE
Add worked example: pre-spend MAKO verification in an A2A x402 flow

### DIFF
--- a/examples/mako-verification/README.md
+++ b/examples/mako-verification/README.md
@@ -1,0 +1,24 @@
+# Pre-spend MAKO verification in an A2A x402 flow
+
+This example shows how a buyer agent in an A2A (Agent-to-Agent) conversation can pre-verify a target service before spending USDC against it, by calling MAKO's Verifier endpoint.
+
+The flow:
+
+1. Buyer agent receives an A2A request with a `paymentRequired` action targeting `https://target.example/api/foo`.
+2. Before signing, buyer calls MAKO's `/api/agent-commerce/verify` ($0.25 USDC).
+3. MAKO inspects the target's `/.well-known/x402.json`, validates schemas, checks settlement readiness, and returns a verdict + recommended call plan + signed receipt.
+4. If the verdict is `callable` and score ≥ 70, buyer proceeds with the original A2A payment.
+5. If not, buyer responds in the A2A conversation with the MAKO warnings instead of paying.
+
+Total cost: $0.25 + the original target call. The verification receipt is hash-anchored so the buyer can persist it as proof-of-due-diligence in case of dispute.
+
+## Run it
+
+```bash
+npm install
+AGENT_PRIVATE_KEY=0x... TARGET_URL=https://some-x402-service node agent.ts
+```
+
+## Composability
+
+For high-volume buyers, the Verifier is overkill on every call. The cheap pattern is to pre-screen with MAKO Pulse ($0.02) and only escalate to the Verifier when Pulse signals trouble. See the [MAKO architecture docs](https://github.com/ChrisDover/mako-verifier/blob/main/ARCHITECTURE.md#how-a-buyer-agent-composes-the-pillars) for that pattern and others.

--- a/examples/mako-verification/README.md
+++ b/examples/mako-verification/README.md
@@ -16,7 +16,7 @@ Total cost: $0.25 + the original target call. The verification receipt is hash-a
 
 ```bash
 npm install
-AGENT_PRIVATE_KEY=0x... TARGET_URL=https://some-x402-service node agent.ts
+AGENT_PRIVATE_KEY=0x... TARGET_URL=https://some-x402-service npx tsx agent.ts
 ```
 
 ## Composability

--- a/examples/mako-verification/agent.ts
+++ b/examples/mako-verification/agent.ts
@@ -1,0 +1,61 @@
+/**
+ * A2A buyer agent that pre-verifies any payment target via MAKO before signing.
+ *
+ * The "A2A x402 flow" simulated here is intentionally minimal — production
+ * integrations should use the official A2A SDK for the conversation transport.
+ */
+
+import { verifyTargetWithMako } from "./mako-helper.js";
+
+interface A2APaymentRequiredAction {
+  type: "paymentRequired";
+  target_url: string;
+  intended_task: string;
+  max_price_usdc: number;
+}
+
+async function handleA2APayment(action: A2APaymentRequiredAction) {
+  console.log(`A2A payment requested → ${action.target_url}`);
+
+  const verdict = await verifyTargetWithMako({
+    target_url: action.target_url,
+    intended_task: action.intended_task,
+    max_price_usdc: action.max_price_usdc,
+    risk_mode: "strict",
+  });
+
+  if (verdict.verdict !== "callable" || verdict.score < 70) {
+    console.warn("MAKO blocked the call:");
+    for (const w of verdict.warnings) console.warn(" -", w);
+    return {
+      type: "a2a_response",
+      status: "blocked_by_verifier",
+      reason: verdict.warnings.join("; ") || "verdict not callable",
+      receipt: verdict.receipt,
+    };
+  }
+
+  console.log(`MAKO cleared the call (score ${verdict.score}). Proceeding.`);
+  console.log("Recommended call plan:", verdict.call_plan);
+
+  return {
+    type: "a2a_response",
+    status: "verified_and_ready",
+    mako_score: verdict.score,
+    mako_receipt: verdict.receipt,
+  };
+}
+
+const inbound: A2APaymentRequiredAction = {
+  type: "paymentRequired",
+  target_url: process.env.TARGET_URL ?? "https://mako.pollinateresearch.com",
+  intended_task: "Fetch latest governance proposal signal for arbitrumfoundation.eth",
+  max_price_usdc: 0.10,
+};
+
+handleA2APayment(inbound)
+  .then((result) => console.log("\nResponse:", JSON.stringify(result, null, 2)))
+  .catch((err) => {
+    console.error("Failed:", err);
+    process.exit(1);
+  });

--- a/examples/mako-verification/agent.ts
+++ b/examples/mako-verification/agent.ts
@@ -26,11 +26,11 @@ async function handleA2APayment(action: A2APaymentRequiredAction) {
 
   if (verdict.verdict !== "callable" || verdict.score < 70) {
     console.warn("MAKO blocked the call:");
-    for (const w of verdict.warnings) console.warn(" -", w);
+    for (const w of verdict.warnings ?? []) console.warn(" -", w);
     return {
       type: "a2a_response",
       status: "blocked_by_verifier",
-      reason: verdict.warnings.join("; ") || "verdict not callable",
+      reason: verdict.warnings?.join("; ") || "verdict not callable",
       receipt: verdict.receipt,
     };
   }
@@ -50,7 +50,7 @@ const inbound: A2APaymentRequiredAction = {
   type: "paymentRequired",
   target_url: process.env.TARGET_URL ?? "https://mako.pollinateresearch.com",
   intended_task: "Fetch latest governance proposal signal for arbitrumfoundation.eth",
-  max_price_usdc: 0.10,
+  max_price_usdc: 0.50,
 };
 
 handleA2APayment(inbound)

--- a/examples/mako-verification/mako-helper.ts
+++ b/examples/mako-verification/mako-helper.ts
@@ -1,0 +1,27 @@
+/**
+ * Thin MAKO Verifier helper. Wraps the @pollinate/mako SDK.
+ */
+
+import { MakoClient, type VerifyRequest, type VerifyResponse } from "@pollinate/mako";
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+
+let _mako: MakoClient | null = null;
+
+function getMakoClient(): MakoClient {
+  if (_mako) return _mako;
+  const pk = process.env.AGENT_PRIVATE_KEY as `0x${string}` | undefined;
+  if (!pk) throw new Error("Set AGENT_PRIVATE_KEY=0x... in env");
+  const wallet = createWalletClient({
+    account: privateKeyToAccount(pk),
+    chain: base,
+    transport: http(process.env.BASE_RPC_URL),
+  });
+  _mako = new MakoClient({ wallet });
+  return _mako;
+}
+
+export async function verifyTargetWithMako(req: VerifyRequest): Promise<VerifyResponse> {
+  return getMakoClient().verify(req);
+}


### PR DESCRIPTION
This PR adds a worked example showing how a buyer agent in an A2A x402 flow can pre-verify a payment target before signing, using the MAKO Verifier ($0.25 USDC on Base).

## Why this is useful in A2A x402 specifically

A2A conversations frequently include `paymentRequired` actions where one agent asks another to spend USDC against a third-party x402 service. The current A2A x402 examples assume the buyer agent has out-of-band knowledge that the target is trustworthy. In practice, buyer agents need a programmatic pre-spend check.

MAKO's Verifier inspects the target's `/.well-known/x402.json`, validates route schemas, checks settlement readiness, and returns a machine-readable verdict + signed receipt — all in one paid HTTP round trip. The example shows the buyer agent calling MAKO before continuing the A2A conversation, and either proceeding (with the MAKO receipt persisted as proof-of-due-diligence) or responding to the requester with the specific warnings that blocked the payment.

## What's in the PR

- `examples/mako-verification/README.md` — explains the flow and the cheap-pre-screen-with-Pulse pattern for high-volume buyers
- `examples/mako-verification/agent.ts` — minimal buyer agent that handles a simulated A2A payment-required action
- `examples/mako-verification/mako-helper.ts` — thin wrapper around the `@pollinate/mako` SDK

The example uses MAKO's reference deployment at `mako.pollinateresearch.com` (Base mainnet, USDC, CDP facilitator) but works against any compatible MAKO instance via the SDK's `baseUrl` config.

## Verification you can do without merging

- `curl https://mako.pollinateresearch.com/.well-known/x402.json` — full route table including the verifier
- `curl -X POST https://mako.pollinateresearch.com/api/agent-commerce/verify` — returns 402 with a valid `payment-required` header
- Live Pulse scoreboard at https://mako.pollinateresearch.com/pulse — 142 services scored across the agentic.market directory

Happy to restructure the example, simplify, or split into smaller pieces if any of this is too much for an examples entry. The goal is to give A2A x402 implementers a copy-pasteable starting point for pre-spend verification.

MAKO source: https://github.com/ChrisDover/mako-verifier (MIT)
Operator: Pollinate Research (Chris Dover, chrisdmacro.base.eth)