### PR TITLE
docs: fix repo name in README directory tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Enable **agent commerce** by providing a standardized way for agents to charge f
 This repository contains the specification, core libraries, and example implementations for the A2A x402 extension, supporting multiple languages.
 
 ```
-x402-a2a/
+a2a-x402/
 ├── spec/
 │   └── v0.1/
 │       └── spec.md         # The official x402 extension specification


### PR DESCRIPTION
### What
Change `x402-a2a/` to `a2a-x402/` in the repository structure diagram.

### Why
The tree label doesn't match the actual repository name (`google-agentic-commerce/a2a-x402`), which is confusing for first-time contributors trying to orient themselves.

Small, scoped fix from kcolbchain contrib-bot.