### PR TITLE
fix: validate payment timeout values

### DIFF
--- a/python/x402_a2a/src/x402_a2a/core/merchant.py
+++ b/python/x402_a2a/src/x402_a2a/core/merchant.py
@@ -51,6 +51,13 @@ def create_payment_requirements(
         PaymentRequirements object ready for x402PaymentRequiredResponse
     """
 
+    if not isinstance(max_timeout_seconds, int) or isinstance(
+        max_timeout_seconds, bool
+    ):
+        raise ValueError("max_timeout_seconds must be an integer")
+    if max_timeout_seconds <= 0:
+        raise ValueError("max_timeout_seconds must be positive")
+
     max_amount_required, asset_address, eip712_domain = process_price_to_atomic_amount(
         price, network
     )

--- a/python/x402_a2a/tests/test_core.py
+++ b/python/x402_a2a/tests/test_core.py
@@ -26,6 +26,7 @@ from x402_a2a.types import (
     SettleResponse,
 )
 from x402_a2a.core.utils import x402Utils
+from x402_a2a.core.merchant import create_payment_requirements
 
 # --- Fixtures ---
 
@@ -127,6 +128,40 @@ def test_get_payment_payload_from_message(utils, sample_payment_payload):
     assert isinstance(extracted_payload, PaymentPayload)
     assert extracted_payload.scheme == "exact"
     assert extracted_payload.payload.signature == "0xabc"
+
+
+def test_create_payment_requirements_rejects_invalid_timeouts(monkeypatch):
+    """Payment requirements should not include invalid timeout values."""
+
+    monkeypatch.setattr(
+        "x402_a2a.core.merchant.process_price_to_atomic_amount",
+        lambda price, network: ("100", "0x456", {}),
+    )
+
+    for timeout in (0, -1, 1.5, True):
+        with pytest.raises(ValueError):
+            create_payment_requirements(
+                price="$1.00",
+                pay_to_address="0x123",
+                resource="/test",
+                max_timeout_seconds=timeout,
+            )
+
+
+def test_create_payment_requirements_accepts_positive_integer_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "x402_a2a.core.merchant.process_price_to_atomic_amount",
+        lambda price, network: ("100", "0x456", {}),
+    )
+
+    requirements = create_payment_requirements(
+        price="$1.00",
+        pay_to_address="0x123",
+        resource="/test",
+        max_timeout_seconds=60,
+    )
+
+    assert requirements.max_timeout_seconds == 60
 
 
 # --- Tests for x402ServerExecutor ---


### PR DESCRIPTION
`create_payment_requirements` accepted invalid timeout values and passed them into the generated payment requirements.

This adds a small validation step so the timeout must be a positive integer before the payment requirement is built. It also adds regression coverage for zero, negative, fractional, and boolean values.
