### PR TITLE
feat(examples): InterlineExecutor — non-custodial x402 settlement via a neutral router

### DIFF
--- a/python/examples/interline-cross-rail/README.md
+++ b/python/examples/interline-cross-rail/README.md
@@ -1,0 +1,89 @@
+# Settle A2A x402 payments through Interline (non-custodial, no facilitator to run)
+
+> Implement a2a-x402's `x402ServerExecutor` with [Interline](https://github.com/Choppaaahh/interline-routes)
+> as the verify/settle backend, so your A2A merchant agent **runs no facilitator and holds no keys.**
+
+a2a-x402 ships `x402ServerExecutor` as an **abstract base** — it drives the A2A x402
+protocol but leaves two methods for you:
+
+```python
+async def verify_payment(self, payload, requirements) -> VerifyResponse: ...
+async def settle_payment(self, payload, requirements) -> SettleResponse: ...
+```
+
+…because *who checks the signature and moves the funds* is a deployment choice. This
+example points them at **Interline**, a neutral, non-custodial cross-rail x402 router.
+The result:
+
+- **No facilitator to operate, no keys to hold.** Interline verifies + settles; funds
+  move buyer → your wallet directly. Interline never custodies.
+- **Rail-agnostic settlement.** Today the same code settles **Base/EVM** x402. When
+  a2a-x402 bumps its `x402` pin to a Solana-capable release, the *same* executor settles
+  **Solana** too — no merchant change.
+
+## How it composes (and why it's HTTP, not an import)
+
+a2a-x402 pins `x402==0.3.x` (`x402.types`); Interline's router runs on `x402>=2`
+(`x402.http`). They can't share one Python process — and they were never meant to.
+Interline is a **facilitator service**, addressed over the **x402 wire protocol**
+(`POST /verify`, `POST /settle`, JSON bodies) which is stable across `x402` library
+versions. So `InterlineExecutor` is a thin *client*: it serializes the x402 objects to
+the wire shape, hands them to Interline's endpoint, and maps the response back. Zero
+shared dependency, zero version conflict.
+
+```
+A2A buyer agent ──pays──▶ your merchant agent
+                          └─ InterlineExecutor(x402ServerExecutor)
+                               verify_payment / settle_payment
+                                     │  x402 wire protocol (HTTP/JSON)
+                                     ▼
+                          Interline facilitator (neutral, non-custodial)
+                               └─ settles on the right rail → your wallet
+```
+
+## Files
+
+| File | What |
+|---|---|
+| `interline_executor.py` | `InterlineExecutor(x402ServerExecutor)` + `interline_facilitator(base_url)` HTTP client |
+| `selftest.py` | mock-verifies verify/settle mapping — **zero network, no A2A runtime** |
+
+## Install (the versions a2a-x402 pins — not pip-latest)
+
+```bash
+pip install "git+https://github.com/google-agentic-commerce/a2a-x402#subdirectory=python/x402_a2a" \
+            "a2a-sdk==0.3.1" "x402==0.3.0"
+```
+
+## Verify it works (no wallet, no chain, no Interline server)
+
+```bash
+python selftest.py
+# -> SELFTEST PASS   (happy path + rejected-payment + network fall-through)
+```
+
+The selftest injects stub facilitator responses and asserts the x402 `VerifyResponse` /
+`SettleResponse` come back correctly mapped — so it proves the integration logic without
+standing up an agent runtime or a payment server.
+
+## Use it for real
+
+```python
+from interline_executor import InterlineExecutor, interline_facilitator
+
+verify_fn, settle_fn = interline_facilitator("https://your-interline-endpoint")  # needs httpx
+executor = InterlineExecutor(your_agent_executor, x402_config,
+                             verify_fn=verify_fn, settle_fn=settle_fn)
+# register `executor` with your A2A server exactly like any x402ServerExecutor.
+```
+
+Point `interline_facilitator(...)` at your Interline deployment. Your wallet address
+lives in the `PaymentRequirements` you advertise; Interline settles to it directly and
+never holds funds.
+
+## Notes
+
+- Non-custodial end-to-end — neither a2a-x402 nor Interline custodies funds.
+- The `verify_fn` / `settle_fn` seam is injectable, so swapping Interline for any other
+  x402 facilitator (or a test stub) is a one-line change — the executor doesn't care.
+- Happy to adjust framing/path or trim — just say the word.

--- a/python/examples/interline-cross-rail/interline_executor.py
+++ b/python/examples/interline-cross-rail/interline_executor.py
@@ -1,0 +1,158 @@
+"""InterlineExecutor — settle an A2A merchant's x402 payments through Interline,
+non-custodially, without running your own facilitator.
+
+a2a-x402 ships `x402ServerExecutor` as an ABSTRACT base: it drives the A2A payment
+protocol (the `execute()` loop, the x402 extension handshake) but leaves two methods
+for YOU to implement —
+
+    async verify_payment(payload, requirements) -> VerifyResponse
+    async settle_payment(payload, requirements) -> SettleResponse
+
+— because *who actually checks the signature and moves the funds* is a deployment
+choice. Most examples point those at a facilitator you host. This one points them at
+[Interline](https://github.com/Choppaaahh/interline-routes), a **neutral, non-custodial
+cross-rail x402 router**, so the merchant agent:
+
+  * runs **no facilitator** and holds **no keys** (Interline verifies + settles; funds
+    move buyer -> your wallet directly, Interline never custodies),
+  * gets a **rail-agnostic** settlement path — today the same code settles Base/EVM
+    x402; when a2a-x402 bumps its `x402` dependency to a Solana-capable version, the
+    *same* executor settles Solana too, no merchant change.
+
+## Why this talks to Interline over HTTP, not via import
+
+a2a-x402 pins `x402==0.3.x` (module `x402.types`); Interline's router runs on
+`x402>=2` (module `x402.http`). The two can't share one Python process. That's fine —
+they were never meant to: Interline is a **facilitator service**, and a facilitator is
+addressed over the **x402 wire protocol** (`POST /verify`, `POST /settle` with JSON
+bodies), which is stable across `x402` library versions. So this executor is a thin
+*client*: it serializes the x402 objects to the wire shape, hands them to Interline's
+endpoint, and maps the response back. No shared dependency, no version conflict.
+
+The `verify_fn` / `settle_fn` seam is injectable so the whole thing is unit-testable
+with zero network (see selftest.py).
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from x402_a2a import x402ServerExecutor
+from x402.types import (
+    PaymentPayload,
+    PaymentRequirements,
+    SettleResponse,
+    VerifyResponse,
+)
+
+# A facilitator client is just: (payment_wire, requirements_wire) -> response_dict.
+# Prod = an HTTP POST to Interline; tests inject a stub. Kept as a plain callable so
+# the executor never imports Interline's (version-incompatible) Python package.
+FacilitatorFn = Callable[[dict, dict], dict]
+
+
+class InterlineExecutor(x402ServerExecutor):
+    """An `x402ServerExecutor` whose verify/settle route to Interline.
+
+    Parameters
+    ----------
+    delegate : AgentExecutor
+        The A2A agent that does the actual paid work (handed straight to the base class).
+    config : x402ExtensionConfig
+        The x402 A2A extension config (handed straight to the base class).
+    verify_fn, settle_fn : (payment: dict, requirements: dict) -> dict
+        How payments are verified / settled. In production, build these with
+        `interline_facilitator(base_url)` (HTTP to Interline). In tests, inject stubs.
+    """
+
+    def __init__(
+        self,
+        delegate,
+        config,
+        *,
+        verify_fn: FacilitatorFn,
+        settle_fn: FacilitatorFn,
+    ) -> None:
+        super().__init__(delegate, config)
+        if not callable(verify_fn) or not callable(settle_fn):
+            raise TypeError("verify_fn and settle_fn must be callables (payment, requirements) -> dict")
+        self._verify_fn = verify_fn
+        self._settle_fn = settle_fn
+
+    async def verify_payment(
+        self, payload: PaymentPayload, requirements: PaymentRequirements
+    ) -> VerifyResponse:
+        """Validate the buyer's signed payment without moving funds — via Interline."""
+        raw = self._verify_fn(_wire(payload), _wire(requirements))
+        is_valid = bool(raw.get("is_valid", raw.get("isValid", False)))
+        return VerifyResponse(
+            is_valid=is_valid,
+            # x402 expects an InvalidReason enum/string; only present when invalid.
+            invalid_reason=None if is_valid else (raw.get("reason") or raw.get("invalid_reason") or "verification_failed"),
+            payer=raw.get("payer") or _payer_of(payload),
+        )
+
+    async def settle_payment(
+        self, payload: PaymentPayload, requirements: PaymentRequirements
+    ) -> SettleResponse:
+        """Move the funds (buyer -> merchant wallet) — via Interline, non-custodially."""
+        raw = self._settle_fn(_wire(payload), _wire(requirements))
+        success = bool(raw.get("success", False))
+        return SettleResponse(
+            success=success,
+            error_reason=None if success else (raw.get("reason") or raw.get("error_reason")),
+            # Interline returns the on-chain tx id under tx_hash/transaction; x402 calls it `transaction`.
+            transaction=(raw.get("transaction") or raw.get("tx_hash") or ""),
+            network=raw.get("network") or requirements.network,
+            payer=raw.get("payer") or _payer_of(payload),
+        )
+
+
+def _wire(obj) -> dict:
+    """Serialize an x402 pydantic object to its wire (camelCase) JSON shape."""
+    return obj.model_dump(by_alias=True, exclude_none=True)
+
+
+def _payer_of(payload: PaymentPayload) -> Optional[str]:
+    """Best-effort buyer address from the signed authorization, for receipts."""
+    try:
+        inner = payload.payload  # ExactPaymentPayload
+        auth = getattr(inner, "authorization", None) or {}
+        if isinstance(auth, dict):
+            return auth.get("from")
+        return getattr(auth, "from_", None) or getattr(auth, "from", None)
+    except (AttributeError, KeyError, TypeError):
+        # best-effort only — a malformed payload shape just means "no payer label";
+        # narrow exceptions so genuine bugs aren't swallowed (QA checklist item 3).
+        return None
+
+
+def interline_facilitator(base_url: str, *, timeout: float = 30.0) -> tuple[FacilitatorFn, FacilitatorFn]:
+    """Build (verify_fn, settle_fn) that POST to a running Interline facilitator.
+
+    Interline exposes the standard x402 facilitator endpoints; this is a thin client so
+    the executor never imports Interline's (version-incompatible) package. Requires
+    `httpx` at runtime (only when you use the real HTTP path — tests inject stubs and
+    need nothing).
+
+    PRODUCTION NOTE (this is an example — harden before real money): a transient 5xx on
+    the *settle* call here raises and propagates, which can leave a payment "in flight"
+    (buyer authorized, settlement unconfirmed). For real deployments, make `settle`
+    **idempotent** (key it on the payment nonce so a retry can't double-settle) and wrap
+    `_post` with bounded retries + a dead-letter path for the unrecoverable case. The
+    seam is intentionally injectable so you can supply a hardened `settle_fn` without
+    touching the executor.
+    """
+    import httpx  # local import: only needed for the live HTTP path
+
+    base = base_url.rstrip("/")
+
+    def _post(path: str, payment: dict, requirements: dict) -> dict:
+        with httpx.Client(timeout=timeout) as c:
+            r = c.post(f"{base}{path}", json={"paymentPayload": payment, "paymentRequirements": requirements})
+            r.raise_for_status()
+            return r.json()
+
+    return (
+        lambda payment, requirements: _post("/verify", payment, requirements),
+        lambda payment, requirements: _post("/settle", payment, requirements),
+    )

--- a/python/examples/interline-cross-rail/selftest.py
+++ b/python/examples/interline-cross-rail/selftest.py
@@ -1,0 +1,129 @@
+"""Mock-verify InterlineExecutor with ZERO network and no A2A agent runtime.
+
+`verify_payment` / `settle_payment` are standalone async methods, so we can exercise
+the whole Interline-routing seam by injecting stub facilitator functions and asserting
+the x402 response objects come back correctly mapped. Golden fixtures (expected values
+computed here, by hand) — the executor must reproduce them exactly.
+
+    python selftest.py        # -> "SELFTEST PASS" + exit 0, or AssertionError + exit 1
+
+Requires the a2a-x402 deps installed at the versions a2a-x402 pins:
+    pip install "git+https://github.com/google-agentic-commerce/a2a-x402#subdirectory=python/x402_a2a" \
+                "a2a-sdk==0.3.1" "x402==0.3.0"
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from a2a.server.agent_execution import AgentExecutor
+from x402.types import ExactPaymentPayload, PaymentPayload, PaymentRequirements
+from x402_a2a.types.config import x402ExtensionConfig
+
+from interline_executor import InterlineExecutor
+
+# --- golden fixtures (the merchant's EVM offer + a buyer's signed payment) ----------
+BUYER = "0xBuyer0000000000000000000000000000000001"
+MERCHANT = "0x000000000000000000000000000000000000dEaD"
+TX = "0xSETTLEMENTtxhash0000000000000000000000000000000000000000000000000001"
+
+REQUIREMENTS = PaymentRequirements(
+    scheme="exact",
+    network="base-sepolia",          # EVM — the only thing a2a-x402's pinned x402 0.3.0 allows
+    max_amount_required="100000",    # 0.10 USDC (6 decimals)
+    resource="https://merchant.example/premium-report",
+    description="Premium report",
+    mime_type="application/json",
+    pay_to=MERCHANT,
+    max_timeout_seconds=120,
+    asset="0x036CbD53842c5426634e7929541eC2318f3dCF7e",  # Base Sepolia test USDC
+    extra={"name": "USDC", "version": "2"},
+)
+
+PAYLOAD = PaymentPayload(
+    x402_version=1,
+    scheme="exact",
+    network="base-sepolia",
+    payload=ExactPaymentPayload(
+        signature="0x" + "ab" * 65,
+        authorization={
+            "from": BUYER,
+            "to": MERCHANT,
+            "value": "100000",
+            "validAfter": "0",
+            "validBefore": "9999999999",
+            "nonce": "0x" + "00" * 32,
+        },
+    ),
+)
+
+
+# --- stubs: a no-op A2A delegate + Interline facilitator responses ------------------
+class _StubAgent(AgentExecutor):
+    async def execute(self, context, event_queue):  # pragma: no cover - never called here
+        ...
+
+    async def cancel(self, context, event_queue):  # pragma: no cover
+        ...
+
+
+CONFIG = x402ExtensionConfig()  # defaults are fine for the verify/settle unit path
+
+
+def _make_executor(verify_raw: dict, settle_raw: dict) -> InterlineExecutor:
+    return InterlineExecutor(
+        _StubAgent(),
+        CONFIG,
+        verify_fn=lambda payment, requirements: verify_raw,
+        settle_fn=lambda payment, requirements: settle_raw,
+    )
+
+
+def main() -> int:
+    # 1) happy path — Interline verifies + settles, executor maps it to x402 responses
+    ex = _make_executor(
+        verify_raw={"is_valid": True, "payer": BUYER},
+        settle_raw={"success": True, "transaction": TX, "network": "base-sepolia", "payer": BUYER},
+    )
+    vr = asyncio.run(ex.verify_payment(PAYLOAD, REQUIREMENTS))
+    assert vr.is_valid is True, vr
+    assert vr.invalid_reason is None, vr
+    assert vr.payer == BUYER, vr
+
+    sr = asyncio.run(ex.settle_payment(PAYLOAD, REQUIREMENTS))
+    assert sr.success is True, sr
+    assert sr.transaction == TX, sr
+    assert sr.network == "base-sepolia", sr
+    assert sr.payer == BUYER, sr
+    print("  [1] happy path: verify is_valid=True, settle tx mapped, payer carried  OK")
+
+    # 2) failure path — a rejected verify must surface is_valid=False + a reason
+    ex2 = _make_executor(
+        verify_raw={"is_valid": False, "reason": "invalid_signature"},
+        settle_raw={"success": False, "reason": "not_settled"},
+    )
+    vr2 = asyncio.run(ex2.verify_payment(PAYLOAD, REQUIREMENTS))
+    assert vr2.is_valid is False, vr2
+    assert vr2.invalid_reason, vr2  # must carry a non-empty reason
+    sr2 = asyncio.run(ex2.settle_payment(PAYLOAD, REQUIREMENTS))
+    assert sr2.success is False, sr2
+    assert sr2.error_reason, sr2
+    print("  [2] failure path: verify is_valid=False+reason, settle success=False+reason  OK")
+
+    # 3) network fall-through — if Interline omits network, executor uses the requirement's
+    ex3 = _make_executor(
+        verify_raw={"is_valid": True},
+        settle_raw={"success": True, "transaction": TX},  # no network key
+    )
+    sr3 = asyncio.run(ex3.settle_payment(PAYLOAD, REQUIREMENTS))
+    assert sr3.network == "base-sepolia", sr3  # fell through to requirements.network
+    # payer fell through to the signed authorization's `from`
+    assert sr3.payer == BUYER, sr3
+    print("  [3] fall-through: missing network->requirements.network, payer<-authorization  OK")
+
+    print("SELFTEST PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this adds

An example implementation of `x402ServerExecutor` whose `verify_payment` / `settle_payment`
route to **[Interline](https://github.com/Choppaaahh/interline-routes)** — a neutral,
non-custodial cross-rail x402 router. It shows a pattern a lot of A2A merchant builders
will want: **gate your agent with x402 but run no facilitator and hold no keys** — a
third-party router verifies the signature and settles funds buyer → your wallet directly.

It also demonstrates the *intended* extension point of `x402ServerExecutor` (the two
abstract methods) with a real, tested backend, which doubles as documentation for anyone
implementing their own.

## Why it's an HTTP client, not an in-process integration

`x402_a2a` pins `x402==0.3.x` (`x402.types`); Interline's router runs on `x402>=2`
(`x402.http`) — they can't co-exist in one interpreter. The example leans into that:
a facilitator is addressed over the **x402 wire protocol** (`POST /verify` / `POST /settle`,
JSON), which is stable across `x402` versions, so `InterlineExecutor` is a thin client and
imports nothing version-incompatible. The `verify_fn`/`settle_fn` seam is injectable, so
the same pattern works for *any* external facilitator (or a test stub).

> Side note for maintainers: because the example only needs `x402.types`, it's a small,
> self-contained illustration that doesn't pull `x402_a2a`'s pin forward. If/when
> `x402_a2a` moves to `x402>=2`, the same executor transparently gains Solana settlement
> (Interline already settles SVM) with no example change.

## Tested

`selftest.py` exercises the full verify/settle seam with injected facilitator responses —
**no network, no agent runtime, no wallet**:

```bash
pip install -e python/x402_a2a   # or the pinned deps below
python python/examples/interline-cross-rail/selftest.py
# -> SELFTEST PASS   (happy path + rejected-payment + network fall-through)
```

(Pinned deps used to validate: `a2a-sdk==0.3.1`, `x402==0.3.0`.)

## Non-custodial

Neither `x402_a2a` nor Interline custodies funds — each rail settles buyer → merchant
wallet directly. The merchant's wallet is the `payTo` in the `PaymentRequirements` it
advertises.

## Notes

- Happy to relocate the path, trim the README, or adjust framing per your examples
  conventions — just let me know.
- No changes to library code; example-only.