### PR TITLE
ci: use locked Ruff in Python workflows

### DIFF
--- a/.github/workflows/python-examples-adk-demo.yml
+++ b/.github/workflows/python-examples-adk-demo.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv sync --group lint
 
       - name: Lint
-        run: uvx ruff check --output-format=github .
+        run: uv run --frozen --group lint ruff check --output-format=github .
 
       - name: Format
-        run: uvx ruff format --check .
+        run: uv run --frozen --group lint ruff format --check .

--- a/.github/workflows/python-examples-adk-demo.yml
+++ b/.github/workflows/python-examples-adk-demo.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -14,10 +17,10 @@ jobs:
         working-directory: python/examples/adk-demo
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/python-x402-a2a.yml
+++ b/.github/workflows/python-x402-a2a.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv sync --group lint
 
       - name: Lint
-        run: uvx ruff check --output-format=github .
+        run: uv run --frozen --group lint ruff check --output-format=github .
 
       - name: Format
-        run: uvx ruff format --check .
+        run: uv run --frozen --group lint ruff format --check .

--- a/.github/workflows/python-x402-a2a.yml
+++ b/.github/workflows/python-x402-a2a.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -14,10 +17,10 @@ jobs:
         working-directory: python/x402_a2a
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
## Summary
- run Ruff through each project's existing uv environment instead of downloading an unpinned release with `uvx`
- enforce the committed lockfiles with `--frozen` in both Python lint workflows
- declare read-only workflow permissions and pin third-party actions to immutable commits, as required by the repository's zizmor policy

This keeps CI reproducible and prevents new Ruff releases from making untouched code fail before the repository deliberately updates its lint dependency.

## Verification
- reproduced the failure on current `main` with Ruff 0.16.1: 99 findings in `python/x402_a2a` and 20 in `python/examples/adk-demo`
- `uv run --frozen --group lint ruff check --output-format=github .` passes in both directories with locked Ruff 0.13.1
- `uv run --frozen --group lint ruff format --check .` passes in both directories
- zizmor 1.25.2 at the repository's CI digest: no findings on either changed workflow
- `git diff --check`
